### PR TITLE
[1.x] Remove `laravel-` prefix from migration tag

### DIFF
--- a/src/PennantServiceProvider.php
+++ b/src/PennantServiceProvider.php
@@ -83,6 +83,6 @@ class PennantServiceProvider extends ServiceProvider
 
         $this->publishes([
             __DIR__.'/../database/migrations' => $this->app->databasePath('migrations'),
-        ], 'laravel-pennant-migrations');
+        ], 'pennant-migrations');
     }
 }


### PR DESCRIPTION
Telescope, Sanctum, Cashier, and Passport all offer migration without the `laravel-` prefix.