### PR TITLE
[1.x] Support an array of features to purge

### DIFF
--- a/src/Commands/PurgeCommand.php
+++ b/src/Commands/PurgeCommand.php
@@ -13,8 +13,8 @@ class PurgeCommand extends Command
      * @var string
      */
     protected $signature = 'pennant:purge
-                            {feature? : The feature to purge}
-                            {--store= : The store to purge the feature from}';
+                            {features?* : The features to purge}
+                            {--store= : The store to purge the features from}';
 
     /**
      * The console command description.
@@ -30,10 +30,10 @@ class PurgeCommand extends Command
      */
     public function handle(FeatureManager $manager)
     {
-        $manager->store($this->option('store'))->purge($this->argument('feature'));
+        $manager->store($this->option('store'))->purge($this->argument('features') ?: null);
 
-        with($this->argument('feature') ?? 'All features', function ($name) {
-            $this->components->info("{$name} successfully purged from storage.");
+        with($this->argument('features') ?: ['All features'], function ($names) {
+            $this->components->info(implode(', ', $names).' successfully purged from storage.');
         });
 
         return self::SUCCESS;

--- a/src/Contracts/Driver.php
+++ b/src/Contracts/Driver.php
@@ -39,9 +39,9 @@ interface Driver
     public function delete(string $feature, mixed $scope): void;
 
     /**
-     * Purge the given feature from storage.
+     * Purge the given features from storage.
      */
-    public function purge(?string $feature): void;
+    public function purge(array|null $features): void;
 
     /**
      * Eagerly preload multiple feature flag values.

--- a/src/Drivers/ArrayDriver.php
+++ b/src/Drivers/ArrayDriver.php
@@ -165,14 +165,16 @@ class ArrayDriver implements Driver
     /**
      * Purge the given feature from storage.
      *
-     * @param  string|null  $feature
+     * @param  array|null  $features
      */
-    public function purge($feature): void
+    public function purge($features): void
     {
-        if ($feature === null) {
+        if ($features === null) {
             $this->resolvedFeatureStates = [];
         } else {
-            unset($this->resolvedFeatureStates[$feature]);
+            foreach ($features as $feature) {
+                unset($this->resolvedFeatureStates[$feature]);
+            }
         }
     }
 

--- a/src/Drivers/DatabaseDriver.php
+++ b/src/Drivers/DatabaseDriver.php
@@ -244,15 +244,15 @@ class DatabaseDriver implements Driver
     /**
      * Purge the given feature from storage.
      *
-     * @param  string|null  $feature
+     * @param  array|null  $features
      */
-    public function purge($feature): void
+    public function purge($features): void
     {
-        if ($feature === null) {
+        if ($features === null) {
             $this->newQuery()->delete();
         } else {
             $this->newQuery()
-                ->where('name', $feature)
+                ->whereIn('name', $features)
                 ->delete();
         }
     }

--- a/src/Drivers/Decorator.php
+++ b/src/Drivers/Decorator.php
@@ -222,22 +222,24 @@ class Decorator implements DriverContract
     /**
      * Purge the given feature from storage.
      *
-     * @param  string|null  $feature
+     * @param  string|array|null  $features
      */
-    public function purge($feature = null): void
+    public function purge($features = null): void
     {
-        if ($feature === null) {
+        if ($features === null) {
             $this->driver->purge(null);
 
             $this->cache = new Collection;
         } else {
-            with($this->resolveFeature($feature), function ($feature) {
-                $this->driver->purge($feature);
+            Collection::wrap($features)
+                ->map($this->resolveFeature(...))
+                ->pipe(function ($features) {
+                    $this->driver->purge($features);
 
-                $this->cache->forget(
-                    $this->cache->whereStrict('feature', $feature)->keys()->all()
-                );
-            });
+                    $this->cache->forget(
+                        $this->cache->whereInStrict('feature', $features)->keys()->all()
+                    );
+                });
         }
     }
 

--- a/src/Feature.php
+++ b/src/Feature.php
@@ -21,7 +21,7 @@ use Illuminate\Support\Facades\Facade;
  * @method static array defined()
  * @method static void activateForEveryone(string|array $feature, mixed $value = true)
  * @method static void deactivateForEveryone(string|array $feature)
- * @method static void purge(string|null $feature = null)
+ * @method static void purge(string|array|null $features = null)
  * @method static array load(string|array $features)
  * @method static array loadMissing(string|array $features)
  * @method static \Laravel\Pennant\Contracts\Driver getDriver()

--- a/tests/Feature/DatabaseDriverTest.php
+++ b/tests/Feature/DatabaseDriverTest.php
@@ -690,6 +690,29 @@ class DatabaseDriverTest extends TestCase
         $this->assertSame(0, DB::table('features')->count());
     }
 
+    public function test_it_can_purge_multiple_flags_at_once()
+    {
+        Feature::define('foo', true);
+        Feature::define('bar', false);
+        Feature::define('baz', false);
+
+        Feature::for('tim')->active('foo');
+        Feature::for('tim')->active('foo');
+        Feature::for('taylor')->active('foo');
+        Feature::for('taylor')->active('bar');
+        Feature::for('taylor')->active('baz');
+
+        $this->assertSame(4, DB::table('features')->count());
+
+        Feature::purge(['foo', 'bar']);
+
+        $this->assertSame(1, DB::table('features')->count());
+
+        Feature::purge(['baz']);
+
+        $this->assertSame(0, DB::table('features')->count());
+    }
+
     public function test_retrieving_values_after_purging()
     {
         Feature::define('foo', false);

--- a/tests/Feature/PurgeCommandTest.php
+++ b/tests/Feature/PurgeCommandTest.php
@@ -32,6 +32,28 @@ class PurgeCommandTest extends TestCase
         $this->assertSame(0, DB::table('features')->count());
     }
 
+    public function test_it_can_purge_multiple_features()
+    {
+        Feature::define('foo', true);
+        Feature::define('bar', true);
+        Feature::define('baz', true);
+
+        Feature::for('tim')->active('foo');
+        Feature::for('tim')->active('bar');
+        Feature::for('taylor')->active('bar');
+        Feature::for('taylor')->active('baz');
+
+        $this->assertSame(4, DB::table('features')->count());
+
+        $this->artisan('pennant:purge foo bar')->expectsOutputToContain('foo, bar successfully purged from storage.');
+
+        $this->assertSame(1, DB::table('features')->count());
+
+        $this->artisan('pennant:purge baz');
+
+        $this->assertSame(0, DB::table('features')->count());
+    }
+
     public function test_it_can_purge_all_feature_flags()
     {
         Feature::define('foo', true);


### PR DESCRIPTION
Currently we only support purging a single feature at a time `Feature::purge('new-api')`.

With this PR we can purge multiple features at a time, allowing for drivers to optimize purging a few features at once.

We still support passing a single feature as a string.

```php
Feature::purge(); // everything

Feature::purge('foo'); // just 'foo'

Feature::purge(['foo', 'bar']); // 'foo' and 'bar'
```

```sh
# everything
php artisan pennant:purge

# just 'foo'
php artisan pennant:purge foo

# 'foo' and 'bar'
php artisan pennant:purge foo bar
```
<img width="565" alt="Screen Shot 2023-02-10 at 2 50 59 pm" src="https://user-images.githubusercontent.com/24803032/217996240-a1c53d73-e4cb-4357-8f76-d8d145634f45.png">

<img width="526" alt="Screen Shot 2023-02-10 at 2 50 47 pm" src="https://user-images.githubusercontent.com/24803032/217996218-5c4b2755-4f51-481f-96ea-9f88f5171a43.png">
