### PR TITLE
[1.x] Load features before checking

### DIFF
--- a/src/Middleware/EnsureFeaturesAreActive.php
+++ b/src/Middleware/EnsureFeaturesAreActive.php
@@ -16,12 +16,12 @@ class EnsureFeaturesAreActive
      */
     public function handle(Request $request, Closure $next, string ...$features): mixed
     {
-        foreach ($features as $feature) {
-            if (! Feature::active($feature)) {
-                return static::$respondUsing
-                    ? call_user_func(static::$respondUsing, $request, $features)
-                    : abort(400);
-            }
+        Feature::loadMissing($features);
+
+        if (Feature::anyAreInactive($feature)) {
+            return static::$respondUsing
+                ? call_user_func(static::$respondUsing, $request, $features)
+                : abort(400);
         }
 
         return $next($request);

--- a/src/Middleware/EnsureFeaturesAreActive.php
+++ b/src/Middleware/EnsureFeaturesAreActive.php
@@ -18,7 +18,7 @@ class EnsureFeaturesAreActive
     {
         Feature::loadMissing($features);
 
-        if (Feature::anyAreInactive($feature)) {
+        if (Feature::anyAreInactive($features)) {
             return static::$respondUsing
                 ? call_user_func(static::$respondUsing, $request, $features)
                 : abort(400);

--- a/src/Middleware/EnsureFeaturesAreActive.php
+++ b/src/Middleware/EnsureFeaturesAreActive.php
@@ -18,7 +18,7 @@ class EnsureFeaturesAreActive
     {
         Feature::loadMissing($features);
 
-        if (Feature::anyAreInactive($features)) {
+        if (Feature::someAreInactive($features)) {
             return static::$respondUsing
                 ? call_user_func(static::$respondUsing, $request, $features)
                 : abort(400);


### PR DESCRIPTION
- Load any missing features.
- Use the more expressive “someAreInactive” method.