### PR TITLE
[1.x] List all features grouped by values

### DIFF
--- a/src/Contracts/Driver.php
+++ b/src/Contracts/Driver.php
@@ -54,7 +54,8 @@ interface Driver
     /**
      * Load all feature flag values.
      *
-     * @return array<string, array<mixed, int>>
+     * @param array<string> $features
+     * @return array<array<string, mixed>>
      */
-    public function listAll(): array;
+    public function stats(array $features = []): array;
 }

--- a/src/Contracts/Driver.php
+++ b/src/Contracts/Driver.php
@@ -50,4 +50,11 @@ interface Driver
      * Purge the given features from storage.
      */
     public function purge(array|null $features): void;
+
+    /**
+     * Load all feature flag values.
+     *
+     * @return array<string, array<mixed, int>>
+     */
+    public function listAll(): array;
 }

--- a/src/Drivers/ArrayDriver.php
+++ b/src/Drivers/ArrayDriver.php
@@ -188,9 +188,18 @@ class ArrayDriver implements Driver
         }
     }
 
-    public function listAll(): array
+    /**
+     * Load all feature flag values.
+     *
+     * @param array<string> $features
+     * @return array<array<string, mixed>>
+     */
+    public function stats(array $features = []): array
     {
         return Collection::make($this->resolvedFeatureStates)
+            ->when(!empty($features), fn($collection) => $collection
+                ->filter(fn($record, $feature) => in_array($feature, $features, true))
+            )
             ->map(function ($records) {
                 return Collection::make($records)
                     ->map(function ($value) {

--- a/src/Drivers/ArrayDriver.php
+++ b/src/Drivers/ArrayDriver.php
@@ -188,6 +188,14 @@ class ArrayDriver implements Driver
         }
     }
 
+    public function listAll(): array
+    {
+        return Collection::make($this->resolvedFeatureStates)
+            ->map(function ($records) {
+                return Collection::make($records)->countBy()->all();
+            })->all();
+    }
+
     /**
      * Determine if the feature does not have a resolver available.
      *

--- a/src/Drivers/ArrayDriver.php
+++ b/src/Drivers/ArrayDriver.php
@@ -192,7 +192,19 @@ class ArrayDriver implements Driver
     {
         return Collection::make($this->resolvedFeatureStates)
             ->map(function ($records) {
-                return Collection::make($records)->countBy()->all();
+                return Collection::make($records)
+                    ->map(function ($value) {
+                        return json_encode($value, flags: JSON_THROW_ON_ERROR);
+                    })
+                    ->countBy()
+                    ->map(function ($count, $value) {
+                        return [
+                            'value' => json_decode($value, flags: JSON_OBJECT_AS_ARRAY | JSON_THROW_ON_ERROR),
+                            'count' => $count
+                        ];
+                    })
+                    ->values()
+                    ->all();
             })->all();
     }
 

--- a/src/Drivers/DatabaseDriver.php
+++ b/src/Drivers/DatabaseDriver.php
@@ -326,23 +326,6 @@ class DatabaseDriver implements Driver
     }
 
     /**
-     * Serialize the given scope for storage.
-     *
-     * @param  mixed  $scope
-     * @return string|null
-     */
-    protected function serializeScope($scope)
-    {
-        return match (true) {
-            $scope === null => '__laravel_null',
-            is_string($scope) => $scope,
-            is_numeric($scope) => (string) $scope,
-            $scope instanceof Model => $scope::class.'|'.$scope->getKey(),
-            default => throw new RuntimeException('Unable to serialize the feature scope to a string. You should implement the FeatureScopeable contract.')
-        };
-    }
-
-    /**
      * Create a new table query.
      *
      * @return \Illuminate\Database\Query\Builder

--- a/src/Drivers/DatabaseDriver.php
+++ b/src/Drivers/DatabaseDriver.php
@@ -302,16 +302,18 @@ class DatabaseDriver implements Driver
     }
 
     /**
-     * Load all feature flags grouped by values.
+     * Load all feature flag values.
      *
-     * @return array<string, array<mixed, int>>
+     * @param array<string> $features
+     * @return array<array<string, mixed>>
      */
-    public function listAll(): array
+    public function stats(array $features = []): array
     {
         $query = $this->newQuery();
 
         $query->select('name', 'value', DB::raw('COUNT(scope) as count'))
-            ->groupBy('name', 'value');
+            ->groupBy('name', 'value')
+            ->when(!empty($features), fn($q) => $q->whereIn('name', $features));
 
         return $query->get()
             ->groupBy('name')

--- a/src/Drivers/DatabaseDriver.php
+++ b/src/Drivers/DatabaseDriver.php
@@ -310,16 +310,15 @@ class DatabaseDriver implements Driver
     {
         $query = $this->newQuery();
 
-        $query->select('name', 'value', DB::raw('COUNT(scope) as total'))
+        $query->select('name', 'value', DB::raw('COUNT(scope) as count'))
             ->groupBy('name', 'value');
 
         return $query->get()
             ->groupBy('name')
             ->map(function ($group) {
-                return $group->mapWithKeys(function ($record) {
+                return $group->map(function ($record) {
                     $value = json_decode($record->value, flags: JSON_OBJECT_AS_ARRAY | JSON_THROW_ON_ERROR);
-
-                    return [$value => $record->total];
+                    return ['value' => $value, 'count' => $record->count];
                 })->all();
             })->all();
     }

--- a/src/Drivers/Decorator.php
+++ b/src/Drivers/Decorator.php
@@ -386,6 +386,33 @@ class Decorator implements DriverContract
     }
 
     /**
+     * Load all feature flags grouped by values.
+     *
+     * @return array<string, array<mixed, int>>
+     */
+    public function listAll(): array
+    {
+        return $this->driver->listAll();
+    }
+
+
+    /**
+     * Eagerly preload multiple feature flag values that are missing.
+     *
+     * @param  string|array<int|string, mixed>  $features
+     * @return array<string, array<int, mixed>>
+     */
+    public function loadMissing($features)
+    {
+        return $this->normalizeFeaturesToLoad($features)
+            ->map(fn ($scopes, $feature) => Collection::make($scopes)
+                ->reject(fn ($scope) => $this->isCached($feature, $scope))
+                ->all())
+            ->reject(fn ($scopes) => $scopes === [])
+            ->pipe(fn ($features) => $this->load($features->all()));
+    }
+
+    /**
      * Resolve the feature name and ensure it is defined.
      *
      * @param  string  $feature

--- a/src/Drivers/Decorator.php
+++ b/src/Drivers/Decorator.php
@@ -386,30 +386,14 @@ class Decorator implements DriverContract
     }
 
     /**
-     * Load all feature flags grouped by values.
+     * Load all feature flag values.
      *
-     * @return array<string, array<mixed, int>>
+     * @param array<string> $features
+     * @return array<array<string, mixed>>
      */
-    public function listAll(): array
+    public function stats(array $features = []): array
     {
-        return $this->driver->listAll();
-    }
-
-
-    /**
-     * Eagerly preload multiple feature flag values that are missing.
-     *
-     * @param  string|array<int|string, mixed>  $features
-     * @return array<string, array<int, mixed>>
-     */
-    public function loadMissing($features)
-    {
-        return $this->normalizeFeaturesToLoad($features)
-            ->map(fn ($scopes, $feature) => Collection::make($scopes)
-                ->reject(fn ($scope) => $this->isCached($feature, $scope))
-                ->all())
-            ->reject(fn ($scopes) => $scopes === [])
-            ->pipe(fn ($features) => $this->load($features->all()));
+        return $this->driver->stats($features);
     }
 
     /**

--- a/src/Feature.php
+++ b/src/Feature.php
@@ -48,6 +48,7 @@ use RuntimeException;
  * @method static void activate(string|array $feature, mixed $value = true)
  * @method static void deactivate(string|array $feature)
  * @method static void forget(string|array $features)
+ * @method static array stats(array $features = [])
  *
  * @see \Laravel\Pennant\FeatureManager
  */

--- a/tests/Feature/ArrayDriverTest.php
+++ b/tests/Feature/ArrayDriverTest.php
@@ -1008,6 +1008,37 @@ class ArrayDriverTest extends TestCase
         $this->assertSame($first[FeatureDependency::class], $firstDependency);
         $this->assertSame($second[FeatureDependency::class], $secondDependency);
     }
+
+    public function test_it_can_list_all_features()
+    {
+        Feature::define('foo', fn() => true);
+
+        $this->assertEquals([], Feature::listAll());
+
+        Feature::for('tim')->activate('foo');
+        Feature::for('taylor')->deactivate('foo');
+
+        $this->assertEquals([
+            'foo' => [
+                true => 1,
+                false => 1,
+            ]
+        ], Feature::listAll());
+
+        Feature::define('bar', function ($name) {
+            return $name === "tim" ? "a" : "b";
+        });
+
+        Feature::for('tim')->active('bar');
+        Feature::for('taylor')->active('bar');
+        Feature::for('ahmed')->active('bar');
+
+        $this->assertEquals([
+            'a' => 1,
+            'b' => 2,
+        ], Feature::listAll()['bar']);
+    }
+
 }
 
 class MyFeature

--- a/tests/Feature/ArrayDriverTest.php
+++ b/tests/Feature/ArrayDriverTest.php
@@ -1020,8 +1020,8 @@ class ArrayDriverTest extends TestCase
 
         $this->assertEquals([
             'foo' => [
-                true => 1,
-                false => 1,
+                ['value' => true, 'count' => 1],
+                ['value' => false, 'count' => 1],
             ]
         ], Feature::listAll());
 
@@ -1034,9 +1034,21 @@ class ArrayDriverTest extends TestCase
         Feature::for('ahmed')->active('bar');
 
         $this->assertEquals([
-            'a' => 1,
-            'b' => 2,
+            ['value' => 'a', 'count' => 1],
+            ['value' => 'b', 'count' => 2],
         ], Feature::listAll()['bar']);
+
+        Feature::define('baz', function ($name) {
+            return $name === "tim" ? ['discount' => 10] : ['discount' => 5];
+        });
+
+        Feature::for('tim')->active('baz');
+        Feature::for('taylor')->active('baz');
+
+        $this->assertEquals([
+            ['value' => ['discount' => 10], 'count' => 1],
+            ['value' => ['discount' => 5], 'count' => 1],
+        ], Feature::listAll()['baz']);
     }
 
 }

--- a/tests/Feature/ArrayDriverTest.php
+++ b/tests/Feature/ArrayDriverTest.php
@@ -1013,7 +1013,7 @@ class ArrayDriverTest extends TestCase
     {
         Feature::define('foo', fn() => true);
 
-        $this->assertEquals([], Feature::listAll());
+        $this->assertEquals([], Feature::stats());
 
         Feature::for('tim')->activate('foo');
         Feature::for('taylor')->deactivate('foo');
@@ -1023,7 +1023,7 @@ class ArrayDriverTest extends TestCase
                 ['value' => true, 'count' => 1],
                 ['value' => false, 'count' => 1],
             ]
-        ], Feature::listAll());
+        ], Feature::stats());
 
         Feature::define('bar', function ($name) {
             return $name === "tim" ? "a" : "b";
@@ -1036,7 +1036,7 @@ class ArrayDriverTest extends TestCase
         $this->assertEquals([
             ['value' => 'a', 'count' => 1],
             ['value' => 'b', 'count' => 2],
-        ], Feature::listAll()['bar']);
+        ], Feature::stats()['bar']);
 
         Feature::define('baz', function ($name) {
             return $name === "tim" ? ['discount' => 10] : ['discount' => 5];
@@ -1048,9 +1048,24 @@ class ArrayDriverTest extends TestCase
         $this->assertEquals([
             ['value' => ['discount' => 10], 'count' => 1],
             ['value' => ['discount' => 5], 'count' => 1],
-        ], Feature::listAll()['baz']);
+        ], Feature::stats()['baz']);
     }
 
+    public function test_it_can_filter_list_of_all_features()
+    {
+        Feature::define('foo', fn() => true);
+        Feature::define('bar', fn() => true);
+
+        Feature::for('tim')->activate('foo');
+        Feature::for('taylor')->deactivate('foo');
+
+        Feature::for('tim')->activate('bar');
+
+        $this->assertCount(2, Feature::stats());
+
+        $this->assertCount(1, Feature::stats(['foo']));
+        $this->assertArrayHasKey('foo', Feature::stats(['foo']));
+    }
 }
 
 class MyFeature

--- a/tests/Feature/DatabaseDriverTest.php
+++ b/tests/Feature/DatabaseDriverTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature;
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\DB;
@@ -1122,6 +1123,36 @@ class DatabaseDriverTest extends TestCase
 
         $result = Feature::for(['tim', 'taylor'])->allAreActive(['foo', 'bar']);
         $this->assertTrue($result);
+    }
+
+    public function test_it_can_list_all_features()
+    {
+        Feature::define('foo', fn() => true);
+
+        $this->assertEquals([], Feature::listAll());
+
+        Feature::for('tim')->activate('foo');
+        Feature::for('taylor')->deactivate('foo');
+
+        $this->assertEquals([
+            'foo' => [
+                true => 1,
+                false => 1,
+            ]
+        ], Feature::listAll());
+
+        Feature::define('bar', function ($name) {
+            return $name === "tim" ? "a" : "b";
+        });
+
+        Feature::for('tim')->active('bar');
+        Feature::for('taylor')->active('bar');
+        Feature::for('ahmed')->active('bar');
+
+        $this->assertEquals([
+            'a' => 1,
+            'b' => 2,
+        ], Feature::listAll()['bar']);
     }
 }
 

--- a/tests/Feature/DatabaseDriverTest.php
+++ b/tests/Feature/DatabaseDriverTest.php
@@ -3,7 +3,6 @@
 namespace Tests\Feature;
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\DB;

--- a/tests/Feature/DatabaseDriverTest.php
+++ b/tests/Feature/DatabaseDriverTest.php
@@ -1136,8 +1136,8 @@ class DatabaseDriverTest extends TestCase
 
         $this->assertEquals([
             'foo' => [
-                true => 1,
-                false => 1,
+                ['value' => false, 'count' => 1],
+                ['value' => true, 'count' => 1],
             ]
         ], Feature::listAll());
 
@@ -1150,9 +1150,21 @@ class DatabaseDriverTest extends TestCase
         Feature::for('ahmed')->active('bar');
 
         $this->assertEquals([
-            'a' => 1,
-            'b' => 2,
+            ['value' => 'a', 'count' => 1],
+            ['value' => 'b', 'count' => 2],
         ], Feature::listAll()['bar']);
+
+        Feature::define('baz', function ($name) {
+            return $name === "tim" ? ['discount' => 10] : ['discount' => 5];
+        });
+
+        Feature::for('tim')->active('baz');
+        Feature::for('taylor')->active('baz');
+
+        $this->assertEquals([
+            ['value' => ['discount' => 10], 'count' => 1],
+            ['value' => ['discount' => 5], 'count' => 1],
+        ], Feature::listAll()['baz']);
     }
 }
 

--- a/tests/Feature/DatabaseDriverTest.php
+++ b/tests/Feature/DatabaseDriverTest.php
@@ -1129,7 +1129,7 @@ class DatabaseDriverTest extends TestCase
     {
         Feature::define('foo', fn() => true);
 
-        $this->assertEquals([], Feature::listAll());
+        $this->assertEquals([], Feature::stats());
 
         Feature::for('tim')->activate('foo');
         Feature::for('taylor')->deactivate('foo');
@@ -1139,7 +1139,7 @@ class DatabaseDriverTest extends TestCase
                 ['value' => false, 'count' => 1],
                 ['value' => true, 'count' => 1],
             ]
-        ], Feature::listAll());
+        ], Feature::stats());
 
         Feature::define('bar', function ($name) {
             return $name === "tim" ? "a" : "b";
@@ -1152,7 +1152,7 @@ class DatabaseDriverTest extends TestCase
         $this->assertEquals([
             ['value' => 'a', 'count' => 1],
             ['value' => 'b', 'count' => 2],
-        ], Feature::listAll()['bar']);
+        ], Feature::stats()['bar']);
 
         Feature::define('baz', function ($name) {
             return $name === "tim" ? ['discount' => 10] : ['discount' => 5];
@@ -1164,7 +1164,23 @@ class DatabaseDriverTest extends TestCase
         $this->assertEquals([
             ['value' => ['discount' => 10], 'count' => 1],
             ['value' => ['discount' => 5], 'count' => 1],
-        ], Feature::listAll()['baz']);
+        ], Feature::stats()['baz']);
+    }
+
+    public function test_it_can_filter_list_of_all_features()
+    {
+        Feature::define('foo', fn() => true);
+        Feature::define('bar', fn() => true);
+
+        Feature::for('tim')->activate('foo');
+        Feature::for('taylor')->deactivate('foo');
+
+        Feature::for('tim')->activate('bar');
+
+        $this->assertCount(2, Feature::stats());
+
+        $this->assertCount(1, Feature::stats(['foo']));
+        $this->assertArrayHasKey('foo', Feature::stats(['foo']));
     }
 }
 


### PR DESCRIPTION
Hello,

Addresses #16, This PR adds `stats` method to all drivers to retrieve a full list of features each one is grouped by values. it gives full visibility on the segments of each feature and how many users/scopes are on which values

```php
Feature::define('segments', function(User $user){
  return Arr::random([
    'a',
    'b',
    'c',
  ]);
});

foreach(User::all() as $user) { # 200 users
  Feature::for($user)->active('segments');
}

dump(Feature::stats());

/** 
output

[
  "segments" => [
    ["value" => "a","count" => 77],
    ["value" => "c","count" => 54],
    ["value" => "b", "count" => 69],
  ],
]
*/
```