### PR TITLE
[Feature] [1.x] Makes PendingScopedFeatureInteraction macroable

### DIFF
--- a/src/PendingScopedFeatureInteraction.php
+++ b/src/PendingScopedFeatureInteraction.php
@@ -3,10 +3,13 @@
 namespace Laravel\Pennant;
 
 use Illuminate\Support\Collection;
+use Illuminate\Support\Traits\Macroable;
 use RuntimeException;
 
 class PendingScopedFeatureInteraction
 {
+    use Macroable;
+
     /**
      * The feature driver.
      *

--- a/tests/Feature/FeatureManagerTest.php
+++ b/tests/Feature/FeatureManagerTest.php
@@ -64,4 +64,13 @@ class FeatureManagerTest extends TestCase
         Feature::load(['foo']);
         $this->assertFalse(Feature::active('foo'));
     }
+
+    public function test_it_can_apply_macros()
+    {
+        Feature::macro('foo', function () {
+            return 'bar';
+        });
+
+        $this->assertEquals('bar', Feature::foo());
+    }
 }


### PR DESCRIPTION
Adds the Macroable trait to PendingScopedFeatureInteraction class. I've added a quick test as well.

This would be useful as I was playing around with Session scoping and felt the most straightforward way would be for the Feature facade to be able to apply a macro. An example would be like this:

```php
Feature::macro('forSession', function () {
    return $this->for('session|'.Session::getId());
});
```