### PR TITLE
[1.x] Auto-discover and register class features

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
         "illuminate/contracts": "^10.0",
         "illuminate/database": "^10.0",
         "illuminate/queue": "^10.0",
-        "illuminate/support": "^10.0"
+        "illuminate/support": "^10.0",
+        "symfony/finder": "^6.0"
     },
     "require-dev": {
         "orchestra/testbench": "^8.0",

--- a/src/Drivers/Decorator.php
+++ b/src/Drivers/Decorator.php
@@ -103,11 +103,11 @@ class Decorator implements DriverContract
     /**
      * Discover and register the application's feature classes.
      *
-     * @param  string|null  $path
      * @param  string  $namespace
+     * @param  string|null  $path
      * @return void
      */
-    public function discover($path = null, $namespace = '\\App\\Features')
+    public function discover($namespace = '\\App\\Features', $path = null, )
     {
         $namespace = Str::finish($namespace, '\\');
 

--- a/src/Drivers/Decorator.php
+++ b/src/Drivers/Decorator.php
@@ -100,11 +100,6 @@ class Decorator implements DriverContract
         });
     }
 
-    // collect([
-    //     Foo::class,
-    //     Bar::class,
-    // ])->each(Feature::define(...));
-
     /**
      * Discover and register the application's feature classes.
      *

--- a/src/Drivers/Decorator.php
+++ b/src/Drivers/Decorator.php
@@ -71,6 +71,25 @@ class Decorator implements DriverContract
     }
 
     /**
+     * Discover and register the application's feature classes.
+     *
+     * @param  string  $namespace
+     * @param  string|null  $path
+     * @return void
+     */
+    public function discover($namespace = '\\App\\Features', $path = null)
+    {
+        $namespace = Str::finish($namespace, '\\');
+
+        Collection::make((new Finder)
+                ->files()
+                ->name('*.php')
+                ->depth(0)
+                ->in($path ?? base_path('app/Features')))
+            ->each(fn ($file) => $this->define("{$namespace}{$file->getBasename('.php')}"));
+    }
+
+    /**
      * Define an initial feature flag state resolver.
      *
      * @param  string|class-string  $feature
@@ -98,25 +117,6 @@ class Decorator implements DriverContract
                 ? $value()
                 : $value;
         });
-    }
-
-    /**
-     * Discover and register the application's feature classes.
-     *
-     * @param  string  $namespace
-     * @param  string|null  $path
-     * @return void
-     */
-    public function discover($namespace = '\\App\\Features', $path = null, )
-    {
-        $namespace = Str::finish($namespace, '\\');
-
-        Collection::make((new Finder)
-                ->files()
-                ->name('*.php')
-                ->depth(0)
-                ->in($path ?? base_path('app/Features')))
-            ->each(fn ($file) => $this->define("{$namespace}{$file->getBasename('.php')}"));
     }
 
 

--- a/src/Drivers/Decorator.php
+++ b/src/Drivers/Decorator.php
@@ -107,7 +107,7 @@ class Decorator implements DriverContract
      * @param  string  $namespace
      * @return void
      */
-    public function discover($path = null, $namespace = '\\App\\Features\\')
+    public function discover($path = null, $namespace = '\\App\\Features')
     {
         $namespace = Str::finish($namespace, '\\');
 

--- a/src/Drivers/Decorator.php
+++ b/src/Drivers/Decorator.php
@@ -9,6 +9,7 @@ use Laravel\Pennant\Contracts\Driver as DriverContract;
 use Laravel\Pennant\Contracts\FeatureScopeable;
 use Laravel\Pennant\Events\DynamicallyDefiningFeature;
 use Laravel\Pennant\PendingScopedFeatureInteraction;
+use Symfony\Component\Finder\Finder;
 
 /**
  * @mixin \Laravel\Pennant\PendingScopedFeatureInteraction
@@ -97,6 +98,29 @@ class Decorator implements DriverContract
                 : $value;
         });
     }
+
+    // collect([
+    //     Foo::class,
+    //     Bar::class,
+    // ])->each(Feature::define(...));
+
+    /**
+     * Discover and register the application's feature classes.
+     *
+     * @param  string|null  $path
+     * @param  string  $namespace
+     * @return void
+     */
+    public function discover($path = null, $namespace = '\\App\\Features\\')
+    {
+        Collection::make((new Finder)
+                ->files()
+                ->name('*.php')
+                ->depth(0)
+                ->in($path ?? base_path('app/Features')))
+            ->each(fn ($file) => $this->define("{$namespace}{$file->getBasename('.php')}"));
+    }
+
 
     /**
      * Retrieve the names of all defined features.

--- a/src/Drivers/Decorator.php
+++ b/src/Drivers/Decorator.php
@@ -5,6 +5,7 @@ namespace Laravel\Pennant\Drivers;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Lottery;
+use Illuminate\Support\Str;
 use Laravel\Pennant\Contracts\Driver as DriverContract;
 use Laravel\Pennant\Contracts\FeatureScopeable;
 use Laravel\Pennant\Events\DynamicallyDefiningFeature;
@@ -113,6 +114,8 @@ class Decorator implements DriverContract
      */
     public function discover($path = null, $namespace = '\\App\\Features\\')
     {
+        $namespace = Str::finish($namespace, '\\');
+
         Collection::make((new Finder)
                 ->files()
                 ->name('*.php')

--- a/tests/Feature/ArrayDriverTest.php
+++ b/tests/Feature/ArrayDriverTest.php
@@ -845,7 +845,7 @@ class ArrayDriverTest extends TestCase
 
         $this->assertSame([
             'marketing-design' => 'marketing-design-value',
-            '\Tests\FeatureClasses\NewApi' => 'new-api-value',
+            '\\Tests\\FeatureClasses\\NewApi' => 'new-api-value',
         ], $all);
     }
 }

--- a/tests/Feature/ArrayDriverTest.php
+++ b/tests/Feature/ArrayDriverTest.php
@@ -839,7 +839,7 @@ class ArrayDriverTest extends TestCase
     public function test_it_can_auto_register_feature_classes()
     {
         Feature::define('marketing-design', 'marketing-design-value');
-        Feature::discover(__DIR__.'/../FeatureClasses', '\\Tests\\FeatureClasses');
+        Feature::discover('\\Tests\\FeatureClasses', __DIR__.'/../FeatureClasses');
 
         $all = Feature::all();
 

--- a/tests/Feature/ArrayDriverTest.php
+++ b/tests/Feature/ArrayDriverTest.php
@@ -835,6 +835,19 @@ class ArrayDriverTest extends TestCase
         $this->assertTrue(Feature::getDriver()->get('foo', 'tim'));
         $this->assertTrue(Feature::getDriver()->get('foo', 'taylor'));
     }
+
+    public function test_it_can_auto_register_feature_classes()
+    {
+        Feature::define('marketing-design', 'marketing-design-value');
+        Feature::discover(__DIR__.'/../FeatureClasses', '\\Tests\\FeatureClasses');
+
+        $all = Feature::all();
+
+        $this->assertSame([
+            'marketing-design' => 'marketing-design-value',
+            '\Tests\FeatureClasses\NewApi' => 'new-api-value',
+        ], $all);
+    }
 }
 
 class MyFeature

--- a/tests/Feature/DatabaseDriverTest.php
+++ b/tests/Feature/DatabaseDriverTest.php
@@ -1016,6 +1016,19 @@ class DatabaseDriverTest extends TestCase
         $this->assertTrue(Feature::getDriver()->get('foo', 'tim'));
         $this->assertTrue(Feature::getDriver()->get('foo', 'taylor'));
     }
+
+    public function test_it_can_auto_register_feature_classes()
+    {
+        Feature::define('marketing-design', 'marketing-design-value');
+        Feature::discover(__DIR__.'/../FeatureClasses', '\\Tests\\FeatureClasses');
+
+        $all = Feature::all();
+
+        $this->assertSame([
+            'marketing-design' => 'marketing-design-value',
+            '\Tests\FeatureClasses\NewApi' => 'new-api-value',
+        ], $all);
+    }
 }
 
 class UnregisteredFeature

--- a/tests/Feature/DatabaseDriverTest.php
+++ b/tests/Feature/DatabaseDriverTest.php
@@ -1020,7 +1020,7 @@ class DatabaseDriverTest extends TestCase
     public function test_it_can_auto_register_feature_classes()
     {
         Feature::define('marketing-design', 'marketing-design-value');
-        Feature::discover(__DIR__.'/../FeatureClasses', '\\Tests\\FeatureClasses');
+        Feature::discover( '\\Tests\\FeatureClasses', __DIR__.'/../FeatureClasses');
 
         $all = Feature::all();
 

--- a/tests/Feature/DatabaseDriverTest.php
+++ b/tests/Feature/DatabaseDriverTest.php
@@ -1026,7 +1026,7 @@ class DatabaseDriverTest extends TestCase
 
         $this->assertSame([
             'marketing-design' => 'marketing-design-value',
-            '\Tests\FeatureClasses\NewApi' => 'new-api-value',
+            '\\Tests\\FeatureClasses\\NewApi' => 'new-api-value',
         ], $all);
     }
 }

--- a/tests/FeatureClasses/NewApi.php
+++ b/tests/FeatureClasses/NewApi.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Tests\FeatureClasses;
+
+class NewApi
+{
+    public function resolve(mixed $scope)
+    {
+        return 'new-api-value';
+    }
+}


### PR DESCRIPTION
## Problem

The `all` method feels misleading when using class based features.

We currently support retrieving feature values for a given scope. 

```php
Feature::define('foo', true);

Feature::all();

// ['foo' => true]
```

> **Note** This method intentionally does not return features that exist in storage that are not registered.

Class based features, unlike closure defined features, are not required to be registered until before they are used.

```php
class App\Features\Foo
{
   public function resolve()
   {
      return true;
   }
}

Feature::all();

// []
```

Once the feature is interacted with, `all` will return it...

```
Feature::active(Foo::class);

Feature::all();

// ['\App\Features\Foo' => true]
```

But then in a fresh request where the feature has not been interacted with...

```php
Feature::all();

// []
```

This is due to the dynamic registration of feature classes, i.e. you do not need to tell the feature driver about the feature before using it. When you use it for the first time in a given request, the feature manager auto-registers the feature.

## Solution

`Feature::discover()`

This new method gives you the best of both worlds. In a service provider you tell the Feature driver to "discover" the classes in your application:

```php
class App\Features\Foo
{
   public function resolve()
   {
      return true;
   }
}


// in a service provider...


public function boot()
{
    Feature::discover();
}


Feature::all();

// ['\App\Features\Foo' => true]
```

If an application does not like touching the filesystem while booting, it is already possible to handle this manually...

```php
public function boot()
{
    collect([
        \App\Features\Foo::class,
        \App\Features\Bar::class,
    ])->each(Feature::define(...));
}
```