### PR TITLE
[1.x] Improve load and loadMissing mechanisms

### DIFF
--- a/src/Contracts/Driver.php
+++ b/src/Contracts/Driver.php
@@ -44,10 +44,10 @@ interface Driver
     public function purge(array|null $features): void;
 
     /**
-     * Eagerly preload multiple feature flag values.
+     * Get multiple feature flag values.
      *
      * @param  array<string, array<int, mixed>>  $features
      * @return array<string, array<int, mixed>>
      */
-    public function load(array $features): array;
+    public function getAll(array $features): array;
 }

--- a/src/Contracts/Driver.php
+++ b/src/Contracts/Driver.php
@@ -19,6 +19,14 @@ interface Driver
     public function defined(): array;
 
     /**
+     * Get multiple feature flag values.
+     *
+     * @param  array<string, array<int, mixed>>  $features
+     * @return array<string, array<int, mixed>>
+     */
+    public function getAll(array $features): array;
+
+    /**
      * Retrieve a feature flag's value.
      */
     public function get(string $feature, mixed $scope): mixed;
@@ -42,12 +50,4 @@ interface Driver
      * Purge the given features from storage.
      */
     public function purge(array|null $features): void;
-
-    /**
-     * Get multiple feature flag values.
-     *
-     * @param  array<string, array<int, mixed>>  $features
-     * @return array<string, array<int, mixed>>
-     */
-    public function getAll(array $features): array;
 }

--- a/src/Drivers/ArrayDriver.php
+++ b/src/Drivers/ArrayDriver.php
@@ -179,12 +179,12 @@ class ArrayDriver implements Driver
     }
 
     /**
-     * Eagerly preload multiple feature flag values.
+     * Get multiple feature flag values.
      *
      * @param  array<string, array<int, mixed>>  $features
      * @return array<string, array<int, mixed>>
      */
-    public function load($features): array
+    public function getAll($features): array
     {
         return Collection::make($features)
             ->map(fn ($scopes, $feature) => Collection::make($scopes)

--- a/src/Drivers/ArrayDriver.php
+++ b/src/Drivers/ArrayDriver.php
@@ -78,6 +78,21 @@ class ArrayDriver implements Driver
     }
 
     /**
+     * Get multiple feature flag values.
+     *
+     * @param  array<string, array<int, mixed>>  $features
+     * @return array<string, array<int, mixed>>
+     */
+    public function getAll($features): array
+    {
+        return Collection::make($features)
+            ->map(fn ($scopes, $feature) => Collection::make($scopes)
+                ->map(fn ($scope) => $this->get($feature, $scope))
+                ->all())
+            ->all();
+    }
+
+    /**
      * Retrieve a feature flag's value.
      *
      * @param  string  $feature
@@ -176,21 +191,6 @@ class ArrayDriver implements Driver
                 unset($this->resolvedFeatureStates[$feature]);
             }
         }
-    }
-
-    /**
-     * Get multiple feature flag values.
-     *
-     * @param  array<string, array<int, mixed>>  $features
-     * @return array<string, array<int, mixed>>
-     */
-    public function getAll($features): array
-    {
-        return Collection::make($features)
-            ->map(fn ($scopes, $feature) => Collection::make($scopes)
-                ->map(fn ($scope) => $this->get($feature, $scope))
-                ->all())
-            ->all();
     }
 
     /**

--- a/tests/Feature/ArrayDriverTest.php
+++ b/tests/Feature/ArrayDriverTest.php
@@ -376,7 +376,7 @@ class ArrayDriverTest extends TestCase
         $this->assertSame(0, $called['foo']);
         $this->assertSame(0, $called['bar']);
 
-        Feature::load(['foo' => 'loaded']);
+        Feature::for('loaded')->load(['foo']);
         $this->assertSame(1, $called['foo']);
         $this->assertSame(0, $called['bar']);
 
@@ -384,7 +384,7 @@ class ArrayDriverTest extends TestCase
         $this->assertSame(1, $called['foo']);
         $this->assertSame(0, $called['bar']);
 
-        Feature::load(['foo' => 'loaded']);
+        Feature::for('loaded')->load('foo');
         $this->assertSame(2, $called['foo']);
         $this->assertSame(0, $called['bar']);
 
@@ -392,7 +392,7 @@ class ArrayDriverTest extends TestCase
         $this->assertSame(2, $called['foo']);
         $this->assertSame(0, $called['bar']);
 
-        Feature::load(['bar' => 'loaded']);
+        Feature::for('loaded')->load('bar');
         $this->assertSame(2, $called['foo']);
         $this->assertSame(1, $called['bar']);
 
@@ -404,7 +404,7 @@ class ArrayDriverTest extends TestCase
         $this->assertSame(2, $called['foo']);
         $this->assertSame(2, $called['bar']);
 
-        Feature::load([
+        Feature::getAll([
             'foo' => [1, 2, 3],
             'bar' => [2],
         ]);
@@ -500,7 +500,7 @@ class ArrayDriverTest extends TestCase
         $this->assertSame(1, $called['foo']);
         $this->assertSame(1, $called['bar']);
 
-        Feature::loadMissing([
+        Feature::getAll([
             'foo' => [1, 2, 3],
             'bar' => [2],
         ]);

--- a/tests/Feature/DatabaseDriverTest.php
+++ b/tests/Feature/DatabaseDriverTest.php
@@ -591,10 +591,10 @@ class DatabaseDriverTest extends TestCase
 
     public function test_unknown_features_are_no_persisted_when_loading()
     {
-        Event::fake([RetrievingUnknownFeature::class]);
+        Event::fake([UnknownFeatureResolved::class]);
         Feature::load(['foo', 'bar']);
 
-        Event::assertDispatchedTimes(RetrievingUnknownFeature::class, 2);
+        Event::assertDispatchedTimes(UnknownFeatureResolved::class, 2);
         $this->assertCount(1, DB::getQueryLog());
         $this->assertCount(0, DB::table('features')->get());
     }


### PR DESCRIPTION
## Problem

The load and loadMissing mechanisms were a little weird. This PR improves them and makes them more expected.


A `load` method was available on both the decorator and the pending scoped interaction, but they had different APIs.

The decorator had the following API:

```php
Feature::load([
   'feature-name' => [$the, $scope, $to, $load, $against],
   'another-feature' => [$the, $scope],
]);
```

This was good as it gave ultimate fine-grained control over what to load and has potential performance benefits when loading for different scopes. However, it meant that if you chain `for` the API changes.

```php
Feature::for([$the, $scope, $to, $load, $against])->load(['feature-name']);

Feature::for([$the, $scope])->load(['another-feature']);
```

Lastly, it is unexpected to me that `load` would work differently with and without the `for` method. I would just expect it to load against the default scope.

## Solution

I have renamed `load` on the driver contract to `getAll`. `getAll` is really an internal API to offer the fine-grained control seen above.

Now `load` and `loadMissing` work in a much more expected way.

```php
// Loads against the default scope...
Feature::load(['feature-a', 'feature-b']);

// Loads against the given scope....
Feature::for(['tim', 'taylor'])->load(['another-a', 'feature-c']);
```

## Notes

- To improve performance I've added `loadMissing` before we retrieve values in a loop.
- Tweaked load methods so we don't do a database query when loading an empty array of features, i.e. a noop.
- Ensure that unknown values are not persisted to the DB when loading in bulk.