### PR TITLE
[1.x] Makes default store configurable via env

### DIFF
--- a/config/pennant.php
+++ b/config/pennant.php
@@ -15,7 +15,7 @@ return [
     |
     */
 
-    'default' => 'database',
+    'default' => env('PENNANT_STORE', 'database'),
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
When it comes to testing, I imagine a lot of applications would like to use the Array driver for a little extra performance gain - especially if using a 3rd party driver that connects over HTTP.

This allows the default driver to be configured via an ENV value.

It is not possible to easily switch to the array driver with in test, the reason being if you register a feature in a service provider:

```php
public function boot()
{
    // default is set to "database" in the config.
    Feature::define('foo', true);
}
```

When in a test that extends the Laravel test case, once we enter the test the service provider has already booted and the feature has been registered against the default driver.

```php
public function test_it_works()
{
    Config::set('pennant.default', 'array');

    // The 'foo' feature we registered against the database store, not the array store.
}
```

With this PR it is possible to set `PENNANT_STORE` in your `.env.testing` or `phpunit.xml`.