### PR TITLE
[1.x] Implements a user-land `HasFeatures` trait

### DIFF
--- a/src/Concerns/HasFeatures.php
+++ b/src/Concerns/HasFeatures.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Laravel\Pennant\Concerns;
+
+use Laravel\Pennant\Feature;
+
+trait HasFeatures
+{
+    /**
+     * Get a scoped feature interaction for the class.
+     *
+     * @param  string|null  $store
+     * @return \Laravel\Pennant\PendingScopedFeatureInteraction
+     */
+    public function features($store = null)
+    {
+        return Feature::store($store)->for($this);
+    }
+}

--- a/tests/Feature/HasFeatureTest.php
+++ b/tests/Feature/HasFeatureTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Support\Facades\Config;
+use Laravel\Pennant\Concerns\HasFeatures;
+use Laravel\Pennant\Contracts\FeatureScopeable;
+use Laravel\Pennant\Feature;
+use Tests\TestCase;
+
+class HasFeatureTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Config::set('pennant.default', 'array');
+    }
+
+    public function test_it_can_check_for_active_features()
+    {
+        Feature::define('foo', 'foo-value');
+        $class = new class implements FeatureScopeable
+        {
+            use HasFeatures;
+
+            public function toFeatureIdentifier(string $driver): mixed
+            {
+                return 'scope';
+            }
+        };
+
+        $value = $class->features()->value('foo');
+
+        $this->assertSame('foo-value', $value);
+    }
+}


### PR DESCRIPTION
This implements a trait to add feature affordances onto models and other objects.

```php
// before

Feature::for($user)->active('foo');

// after

$user->features()->active('foo');
```

The `features` method returns a scoped pending feature interaction, meaning all these methods are available.

```php
$user->features()->active('foo');

$user->features()->value('foo');

$user->features()->values(['foo', 'bar']);

$user->features()->all();

$user->features()->active('foo');

$user->features()->allAreActive(['foo', 'bar']);

$user->features()->someAreActive(['foo', 'bar']);

$user->features()->inactive('foo');

$user->features()->allAreInactive(['foo', 'bar']);

$user->features()->someAreInactive(['foo', 'bar']);

$user->features()->when('foo',
    fn () => /* ... */,
    fn () => /* ... */
);

$user->features()->unless('foo',
    fn () => /* ... */,
    fn () => /* ... */
);

$user->features()->activate('foo');

$user->features()->deactivate('foo');

$user->features()->load(['foo', 'bar']);

$user->features()->loadMissing(['foo', 'bar']);

$user->features()->forget(['foo', 'bar']);
```

The store may be customised:

```php
$user->features('array')->active('foo');
```