### PR TITLE
[1.x] Ensure multi-scope check takes all scopes into account

### DIFF
--- a/src/PendingScopedFeatureInteraction.php
+++ b/src/PendingScopedFeatureInteraction.php
@@ -119,9 +119,9 @@ class PendingScopedFeatureInteraction
      */
     public function someAreActive($features)
     {
-        return Collection::make($features)
-            ->crossJoin($this->scope())
-            ->some(fn ($bits) => $this->driver->get(...$bits) !== false);
+        return Collection::make($this->scope())
+            ->every(fn ($scope) => Collection::make($features)
+                ->some(fn ($feature) => $this->driver->get($feature, $scope) !== false));
     }
 
     /**
@@ -156,9 +156,9 @@ class PendingScopedFeatureInteraction
      */
     public function someAreInactive($features)
     {
-        return Collection::make($features)
-            ->crossJoin($this->scope())
-            ->some(fn ($bits) => $this->driver->get(...$bits) === false);
+        return Collection::make($this->scope())
+            ->every(fn ($scope) => Collection::make($features)
+                ->some(fn ($feature) => $this->driver->get($feature, $scope) === false));
     }
 
     /**

--- a/tests/Feature/DatabaseDriverTest.php
+++ b/tests/Feature/DatabaseDriverTest.php
@@ -1016,6 +1016,79 @@ class DatabaseDriverTest extends TestCase
         $this->assertTrue(Feature::getDriver()->get('foo', 'tim'));
         $this->assertTrue(Feature::getDriver()->get('foo', 'taylor'));
     }
+
+    public function test_it_handles_multiscope_checks()
+    {
+        Feature::define('foo', false);
+
+        $result = Feature::for(['tim', 'taylor'])->allAreInactive(['foo', 'bar']);
+        $this->assertTrue($result);
+
+        $result = Feature::for(['tim', 'taylor'])->someAreInactive(['foo', 'bar']);
+        $this->assertTrue($result);
+
+        $result = Feature::for(['tim', 'taylor'])->someAreActive(['foo', 'bar']);
+        $this->assertFalse($result);
+
+        $result = Feature::for(['tim', 'taylor'])->allAreActive(['foo', 'bar']);
+        $this->assertFalse($result);
+
+        Feature::for('tim')->activate('foo');
+
+        $result = Feature::for(['tim', 'taylor'])->allAreInactive(['foo', 'bar']);
+        $this->assertFalse($result);
+
+        $result = Feature::for(['tim', 'taylor'])->someAreInactive(['foo', 'bar']);
+        $this->assertTrue($result);
+
+        $result = Feature::for(['tim', 'taylor'])->someAreActive(['foo', 'bar']);
+        $this->assertFalse($result);
+
+        $result = Feature::for(['tim', 'taylor'])->allAreActive(['foo', 'bar']);
+        $this->assertFalse($result);
+
+        Feature::for('taylor')->activate('foo');
+
+        $result = Feature::for(['tim', 'taylor'])->allAreInactive(['foo', 'bar']);
+        $this->assertFalse($result);
+
+        $result = Feature::for(['tim', 'taylor'])->someAreInactive(['foo', 'bar']);
+        $this->assertTrue($result);
+
+        $result = Feature::for(['tim', 'taylor'])->someAreActive(['foo', 'bar']);
+        $this->assertTrue($result);
+
+        $result = Feature::for(['tim', 'taylor'])->allAreActive(['foo', 'bar']);
+        $this->assertFalse($result);
+
+        Feature::for('tim')->activate('bar');
+
+        $result = Feature::for(['tim', 'taylor'])->allAreInactive(['foo', 'bar']);
+        $this->assertFalse($result);
+
+        $result = Feature::for(['tim', 'taylor'])->someAreInactive(['foo', 'bar']);
+        $this->assertFalse($result);
+
+        $result = Feature::for(['tim', 'taylor'])->someAreActive(['foo', 'bar']);
+        $this->assertTrue($result);
+
+        $result = Feature::for(['tim', 'taylor'])->allAreActive(['foo', 'bar']);
+        $this->assertFalse($result);
+
+        Feature::for('taylor')->activate('bar');
+
+        $result = Feature::for(['tim', 'taylor'])->allAreInactive(['foo', 'bar']);
+        $this->assertFalse($result);
+
+        $result = Feature::for(['tim', 'taylor'])->someAreInactive(['foo', 'bar']);
+        $this->assertFalse($result);
+
+        $result = Feature::for(['tim', 'taylor'])->someAreActive(['foo', 'bar']);
+        $this->assertTrue($result);
+
+        $result = Feature::for(['tim', 'taylor'])->allAreActive(['foo', 'bar']);
+        $this->assertTrue($result);
+    }
 }
 
 class UnregisteredFeature


### PR DESCRIPTION
Slight change in the functionality when dealing with multi-scope checks. I believe that this should oly return `true` when both `tim` and `taylor` have some active.

```php
Feature::for('tim')->activate('foo');

// This should return false as 'tim' does not have any.
Feature::for(['tim', 'taylor'])->someAreActive(['foo', 'bar']);

Feature::for('taylor')->activate('foo');

// This should return true because both 'tim' and 'taylor' have some.
Feature::for(['tim', 'taylor'])->someAreActive(['foo', 'bar']);
```

Before it was returning true if any of the scope had any of those values. Although the previous functionality could be supported via another API (`Feature::forAny()`), I don't believe it should be the default behaviour.