### PR TITLE
[1.x] Extract serialization to shared helper

### DIFF
--- a/src/Drivers/ArrayDriver.php
+++ b/src/Drivers/ArrayDriver.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Collection;
 use Laravel\Pennant\Contracts\Driver;
 use Laravel\Pennant\Events\FeatureResolved;
 use Laravel\Pennant\Events\UnknownFeatureResolved;
+use Laravel\Pennant\Feature;
 use RuntimeException;
 use stdClass;
 
@@ -100,7 +101,7 @@ class ArrayDriver implements Driver
      */
     public function get($feature, $scope): mixed
     {
-        $scopeKey = $this->serializeScope($scope);
+        $scopeKey = Feature::serializeScope($scope);
 
         if (isset($this->resolvedFeatureStates[$feature][$scopeKey])) {
             return $this->resolvedFeatureStates[$feature][$scopeKey];
@@ -148,7 +149,7 @@ class ArrayDriver implements Driver
     {
         $this->resolvedFeatureStates[$feature] ??= [];
 
-        $this->resolvedFeatureStates[$feature][$this->serializeScope($scope)] = $value;
+        $this->resolvedFeatureStates[$feature][Feature::serializeScope($scope)] = $value;
     }
 
     /**
@@ -174,7 +175,7 @@ class ArrayDriver implements Driver
      */
     public function delete($feature, $scope): void
     {
-        unset($this->resolvedFeatureStates[$feature][$this->serializeScope($scope)]);
+        unset($this->resolvedFeatureStates[$feature][Feature::serializeScope($scope)]);
     }
 
     /**
@@ -212,22 +213,5 @@ class ArrayDriver implements Driver
     public function flushCache()
     {
         $this->resolvedFeatureStates = [];
-    }
-
-    /**
-     * Serialize the given scope for storage.
-     *
-     * @param  mixed  $scope
-     * @return string
-     */
-    protected function serializeScope($scope)
-    {
-        return match (true) {
-            $scope === null => '__laravel_null',
-            is_string($scope) => $scope,
-            is_numeric($scope) => (string) $scope,
-            $scope instanceof Model => $scope::class.'|'.$scope->getKey(),
-            default => throw new RuntimeException('Unable to serialize the feature scope to a string. You should implement the FeatureScopeable contract.')
-        };
     }
 }

--- a/src/Drivers/ArrayDriver.php
+++ b/src/Drivers/ArrayDriver.php
@@ -3,13 +3,11 @@
 namespace Laravel\Pennant\Drivers;
 
 use Illuminate\Contracts\Events\Dispatcher;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
 use Laravel\Pennant\Contracts\Driver;
 use Laravel\Pennant\Events\FeatureResolved;
 use Laravel\Pennant\Events\UnknownFeatureResolved;
 use Laravel\Pennant\Feature;
-use RuntimeException;
 use stdClass;
 
 class ArrayDriver implements Driver

--- a/src/Drivers/DatabaseDriver.php
+++ b/src/Drivers/DatabaseDriver.php
@@ -4,14 +4,12 @@ namespace Laravel\Pennant\Drivers;
 
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Database\Connection;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 use Laravel\Pennant\Contracts\Driver;
 use Laravel\Pennant\Events\FeatureResolved;
 use Laravel\Pennant\Events\UnknownFeatureResolved;
 use Laravel\Pennant\Feature;
-use RuntimeException;
 use stdClass;
 
 class DatabaseDriver implements Driver

--- a/src/Feature.php
+++ b/src/Feature.php
@@ -2,7 +2,9 @@
 
 namespace Laravel\Pennant;
 
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Facade;
+use RuntimeException;
 
 /**
  * @method static mixed store(string|null $store = null)
@@ -53,5 +55,22 @@ class Feature extends Facade
     protected static function getFacadeAccessor()
     {
         return FeatureManager::class;
+    }
+
+    /**
+     * Serialize the given scope for storage.
+     *
+     * @param  mixed  $scope
+     * @return string|null
+     */
+    public static function serializeScope($scope)
+    {
+        return match (true) {
+            $scope === null => '__laravel_null',
+            is_string($scope) => $scope,
+            is_numeric($scope) => (string) $scope,
+            $scope instanceof Model => $scope::class.'|'.$scope->getKey(),
+            default => throw new RuntimeException('Unable to serialize the feature scope to a string. You should implement the FeatureScopeable contract.')
+        };
     }
 }


### PR DESCRIPTION
Trims the fat on the drivers, and leads the way for the dev to specify how to serialize different objects etc in the future and have that shared across drivers.