### PR TITLE
[1.x] Dispatch feature resolved event from decorator

### DIFF
--- a/src/Drivers/ArrayDriver.php
+++ b/src/Drivers/ArrayDriver.php
@@ -6,7 +6,6 @@ use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
 use Laravel\Pennant\Contracts\Driver;
-use Laravel\Pennant\Events\FeatureResolved;
 use Laravel\Pennant\Events\UnknownFeatureResolved;
 use RuntimeException;
 use stdClass;
@@ -132,9 +131,7 @@ class ArrayDriver implements Driver
             return $this->unknownFeatureValue;
         }
 
-        return tap($this->featureStateResolvers[$feature]($scope), function ($value) use ($feature, $scope) {
-            $this->events->dispatch(new FeatureResolved($feature, $scope, $value));
-        });
+        return $this->featureStateResolvers[$feature]($scope);
     }
 
     /**

--- a/src/Drivers/DatabaseDriver.php
+++ b/src/Drivers/DatabaseDriver.php
@@ -8,7 +8,6 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 use Laravel\Pennant\Contracts\Driver;
-use Laravel\Pennant\Events\FeatureResolved;
 use Laravel\Pennant\Events\UnknownFeatureResolved;
 use RuntimeException;
 use stdClass;
@@ -192,9 +191,7 @@ class DatabaseDriver implements Driver
             return $this->unknownFeatureValue;
         }
 
-        return tap($this->featureStateResolvers[$feature]($scope), function ($value) use ($feature, $scope) {
-            $this->events->dispatch(new FeatureResolved($feature, $scope, $value));
-        });
+        return $this->featureStateResolvers[$feature]($scope);
     }
 
     /**


### PR DESCRIPTION
`FeatureResolved` events are now handled by the decorator and no longer a concern of the drivers.

3rd party drivers do not need to worry about this event, unless they are not using the `Feature::define()` functionality. If that is the case, they would need to manually dispatch the event when appropriate.

Both drivers already have tests to ensure this event is dispatched and they continue to pass with this change.