### PR TITLE
[1.x] Gracefully handles unexpected `null` scope

### DIFF
--- a/src/Drivers/Decorator.php
+++ b/src/Drivers/Decorator.php
@@ -141,21 +141,6 @@ class Decorator implements DriverContract
     }
 
     /**
-     * Determine if the resolver accepts null scope.
-     *
-     * @param  callable  $resolver
-     * @return bool
-     */
-    protected function canHandleNullScope($resolver)
-    {
-        $function = new ReflectionFunction(Closure::fromCallable($resolver));
-
-        return $function->getNumberOfParameters() === 0 ||
-            ! $function->getParameters()[0]->hasType() ||
-            $function->getParameters()[0]->getType()->allowsNull();
-    }
-
-    /**
      * Resolve the feature value.
      *
      * @param  string  $feature
@@ -172,6 +157,21 @@ class Decorator implements DriverContract
         $this->container['events']->dispatch(new FeatureResolved($feature, $scope, $value));
 
         return $value;
+    }
+
+    /**
+     * Determine if the resolver accepts null scope.
+     *
+     * @param  callable  $resolver
+     * @return bool
+     */
+    protected function canHandleNullScope($resolver)
+    {
+        $function = new ReflectionFunction(Closure::fromCallable($resolver));
+
+        return $function->getNumberOfParameters() === 0 ||
+            ! $function->getParameters()[0]->hasType() ||
+            $function->getParameters()[0]->getType()->allowsNull();
     }
 
     /**

--- a/src/Events/UnexpectedNullScopeEncountered.php
+++ b/src/Events/UnexpectedNullScopeEncountered.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Laravel\Pennant\Events;
+
+class UnexpectedNullScopeEncountered
+{
+    /**
+     * The feature name.
+     *
+     * @var string
+     */
+    public $feature;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param  string  $feature
+     */
+    public function __construct($feature)
+    {
+        $this->feature = $feature;
+    }
+}

--- a/src/Feature.php
+++ b/src/Feature.php
@@ -7,7 +7,7 @@ use Illuminate\Support\Facades\Facade;
 use RuntimeException;
 
 /**
- * @method static mixed store(string|null $store = null)
+ * @method static \Laravel\Pennant\Drivers\Decorator store(string|null $store = null)
  * @method static \Laravel\Pennant\Drivers\ArrayDriver createArrayDriver()
  * @method static \Laravel\Pennant\Drivers\DatabaseDriver createDatabaseDriver()
  * @method static void flushCache()

--- a/src/FeatureManager.php
+++ b/src/FeatureManager.php
@@ -26,7 +26,7 @@ class FeatureManager extends Manager
      * Get a Pennant store instance.
      *
      * @param  string|null  $store
-     * @return mixed
+     * @return \Laravel\Pennant\Drivers\Decorator
      *
      * @throws \InvalidArgumentException
      */

--- a/src/LazilyResolvedFeature.php
+++ b/src/LazilyResolvedFeature.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Laravel\Pennant;
+
+class LazilyResolvedFeature
+{
+    /**
+     * The feature class.
+     *
+     * @var class-string
+     */
+    public $feature;
+
+    /**
+     * Create a new lazy feature instance.
+     *
+     * @param  class-string  $feature
+     */
+    public function __construct($feature)
+    {
+        $this->feature = $feature;
+    }
+}

--- a/tests/Feature/ArrayDriverTest.php
+++ b/tests/Feature/ArrayDriverTest.php
@@ -2,12 +2,14 @@
 
 namespace Tests\Feature;
 
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Lottery;
 use Laravel\Pennant\Contracts\FeatureScopeable;
 use Laravel\Pennant\Events\FeatureResolved;
+use Laravel\Pennant\Events\UnexpectedNullScopeEncountered;
 use Laravel\Pennant\Events\UnknownFeatureResolved;
 use Laravel\Pennant\Feature;
 use RuntimeException;
@@ -848,6 +850,120 @@ class ArrayDriverTest extends TestCase
             '\\Tests\\FeatureClasses\\NewApi' => 'new-api-value',
         ], $all);
     }
+
+    public function test_it_accepts_null_scope_for_parameterless_feature()
+    {
+        Feature::define('foo', fn () => true);
+
+        $result = Feature::for(null)->active('foo');
+        $this->assertTrue($result);
+
+        $result = Feature::for(new User)->active('foo');
+        $this->assertTrue($result);
+
+        $result = Feature::for(null)->active(MyFeatureWithNoScope::class);
+        $this->assertTrue($result);
+
+        $result = Feature::for(new User)->active(MyFeatureWithNoScope::class);
+        $this->assertTrue($result);
+    }
+
+    public function test_it_accepts_null_scope_for_untyped_feature()
+    {
+        Feature::define('foo', fn ($user) => true);
+
+        $result = Feature::for(null)->active('foo');
+        $this->assertTrue($result);
+
+        $result = Feature::for(new User)->active('foo');
+        $this->assertTrue($result);
+
+        $result = Feature::for(null)->active(MyFeatureWithUntypedScope::class);
+        $this->assertTrue($result);
+
+        $result = Feature::for(new User)->active(MyFeatureWithUntypedScope::class);
+        $this->assertTrue($result);
+    }
+
+    public function test_it_accepts_null_scope_for_mixed_typed_feature()
+    {
+        Feature::define('foo', fn (mixed $user) => true);
+
+        $result = Feature::for(null)->active('foo');
+        $this->assertTrue($result);
+
+        $result = Feature::for(new User)->active('foo');
+        $this->assertTrue($result);
+
+        $result = Feature::for(null)->active(MyFeatureWithMixedScope::class);
+        $this->assertTrue($result);
+
+        $result = Feature::for(new User)->active(MyFeatureWithMixedScope::class);
+        $this->assertTrue($result);
+    }
+
+    public function test_it_accepts_null_scope_for_nullable_typed_feature()
+    {
+        Feature::define('foo', fn (?User $user) => true);
+
+        $result = Feature::for(null)->active('foo');
+        $this->assertTrue($result);
+
+        $result = Feature::for(new User)->active('foo');
+        $this->assertTrue($result);
+
+        $result = Feature::for(null)->active(MyFeatureWithNullableScope::class);
+        $this->assertTrue($result);
+
+        $result = Feature::for(new User)->active(MyFeatureWithNullableScope::class);
+        $this->assertTrue($result);
+    }
+
+    public function test_it_gracefully_handles_null_scope_for_non_nullable_feature()
+    {
+        Event::fake([UnexpectedNullScopeEncountered::class]);
+        Feature::define('foo', function (User $user) {
+            return true;
+        });
+
+        $result = Feature::for(null)->active('foo');
+        $this->assertFalse($result);
+        Event::assertDispatchedTimes(UnexpectedNullScopeEncountered::class, 1);
+        Event::assertDispatched(function (UnexpectedNullScopeEncountered $event) {
+            return $event->feature === 'foo';
+        });
+
+        $result = Feature::for(new User)->active('foo');
+        $this->assertTrue($result);
+        Event::assertDispatchedTimes(UnexpectedNullScopeEncountered::class, 1);
+
+        $result = Feature::for(null)->active(MyFeatureWithUserScope::class);
+        $this->assertFalse($result);
+        Event::assertDispatchedTimes(UnexpectedNullScopeEncountered::class, 2);
+        Event::assertDispatched(function (UnexpectedNullScopeEncountered $event) {
+            return $event->feature === MyFeatureWithUserScope::class;
+        });
+
+        $result = Feature::for(new User)->active(MyFeatureWithUserScope::class);
+        $this->assertTrue($result);
+        Event::assertDispatchedTimes(UnexpectedNullScopeEncountered::class, 2);
+    }
+
+    public function test_it_does_not_interpret_array_as_callable()
+    {
+        $class = new class
+        {
+            public function foo()
+            {
+                return 'xxxx';
+            }
+        };
+        Feature::define('foo', [$class, 'foo']);
+
+        $result = Feature::value('foo');
+
+        $this->assertSame([$class, 'foo'], $result);
+    }
 }
 
 class MyFeature
@@ -873,5 +989,45 @@ class MyFeatureWithResolveMethod
     public function resolve($scope)
     {
         return "{$scope}-resolve-123";
+    }
+}
+
+class MyFeatureWithUserScope
+{
+    public function resolve(User $user)
+    {
+        return true;
+    }
+}
+
+class MyFeatureWithNoScope
+{
+    public function resolve()
+    {
+        return true;
+    }
+}
+
+class MyFeatureWithUntypedScope
+{
+    public function resolve($scope)
+    {
+        return true;
+    }
+}
+
+class MyFeatureWithMixedScope
+{
+    public function resolve(mixed $scope)
+    {
+        return true;
+    }
+}
+
+class MyFeatureWithNullableScope
+{
+    public function resolve(?User $scope)
+    {
+        return true;
     }
 }

--- a/tests/Feature/ArrayDriverTest.php
+++ b/tests/Feature/ArrayDriverTest.php
@@ -3,7 +3,6 @@
 namespace Tests\Feature;
 
 use Illuminate\Container\Container;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Event;
@@ -971,7 +970,8 @@ class ArrayDriverTest extends TestCase
         $createContainer = function () {
             $container = new Container();
             $container->singleton(FeatureDependency::class);
-            $container->instance('events', new class {
+            $container->instance('events', new class
+            {
                 public function dispatch()
                 {
                     //


### PR DESCRIPTION
This PR gracefully handles `null` scope when a feature definition / resolver has a non-nullable type declaration.

```php
Feature::define('api-beta', fn (User $user) => true);

Auth::logout();

Feature::active('api-beta');
```

Instead of throwing a type exception when checking if the feature is active, we will now return `false` and dispatch the `Laravel\Pennant\Events\UnexpectedNullScopeEncountered` event.

This is a sensible default and is functionality already present in Laravel Authorisation Guards.

If an app wants to opt-out of this behaviour:

```php
use Laravel\Pennant\Events\UnexpectedNullScopeEncountered;

Event::listen(UnexpectedNullScopeEncountered::class, fn () => abort(500));
```