### PR TITLE
Remove migration file registration

### DIFF
--- a/src/PennantServiceProvider.php
+++ b/src/PennantServiceProvider.php
@@ -79,8 +79,6 @@ class PennantServiceProvider extends ServiceProvider
      */
     protected function offerPublishing()
     {
-        $this->loadMigrationsFrom(__DIR__.'/../database/migrations');
-
         $this->publishes([
             __DIR__.'/../config/pennant.php' => config_path('pennant.php'),
         ], 'pennant-config');


### PR DESCRIPTION
When running `php artisan vendor:publish --provider="Laravel\Pennant\PennantServiceProvider"` the migration has been published to the base `database/migrations` directory, and after that when we run `php artisan migrate`, both migration files will be ran and will get the same name error.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
