### PR TITLE
Fix table name not being used and migration error

### DIFF
--- a/src/FeatureManager.php
+++ b/src/FeatureManager.php
@@ -77,7 +77,7 @@ class FeatureManager extends Manager
      */
     public function createDatabaseDriver()
     {
-        return with($this->container['config']->get('pennant.drivers.database'), function ($config) {
+        return with($this->container['config']->get('pennant.stores.database'), function ($config) {
             return new DatabaseDriver(
                 $this->container['db']->connection($config['connection'] ?? null),
                 $this->container['events'],

--- a/src/PennantServiceProvider.php
+++ b/src/PennantServiceProvider.php
@@ -79,8 +79,6 @@ class PennantServiceProvider extends ServiceProvider
      */
     protected function offerPublishing()
     {
-        $this->loadMigrationsFrom(__DIR__.'/../database/migrations');
-
         $this->publishes([
             __DIR__.'/../config/pennant.php' => config_path('pennant.php'),
         ], 'pennant-config');


### PR DESCRIPTION
The pennant config is using `stores` and same when creating driver in FeatureManager, however, when configuring database driver, it reads from `drivers` which is not found.

According to the docs, we were asked to run `php artisan vendor:publish --provider="Laravel\Pennant\PennantServiceProvider"` and the migration will be published to the base `database/migrations` directory.

And after that when we run `php artisan migrate`, both migration files will be ran and causes error.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
