### PR TITLE
Better way to retrieve the database connection.

### DIFF
--- a/src/Drivers/DatabaseDriver.php
+++ b/src/Drivers/DatabaseDriver.php
@@ -10,16 +10,10 @@ use Laravel\Pennant\Contracts\Driver;
 use Laravel\Pennant\Events\UnknownFeatureResolved;
 use Laravel\Pennant\Feature;
 use stdClass;
+use Illuminate\Support\Facades\DB;
 
 class DatabaseDriver implements Driver
 {
-    /**
-     * The database connection.
-     *
-     * @var \Illuminate\Database\Connection
-     */
-    protected $db;
-
     /**
      * The user configuration.
      *
@@ -55,9 +49,8 @@ class DatabaseDriver implements Driver
      * @param  array<string, (callable(mixed $scope): mixed)>  $featureStateResolvers
      * @return void
      */
-    public function __construct(Connection $db, Dispatcher $events, $config, $featureStateResolvers)
+    public function __construct(Dispatcher $events, $config, $featureStateResolvers)
     {
-        $this->db = $db;
         $this->events = $events;
         $this->config = $config;
         $this->featureStateResolvers = $featureStateResolvers;
@@ -313,6 +306,7 @@ class DatabaseDriver implements Driver
      */
     protected function newQuery()
     {
-        return $this->db->table($this->config['table'] ?? 'features');
+        $db = DB::connection($this->config['connection'] ?? null);
+        return $db->table($this->config['table'] ?? 'features');
     }
 }

--- a/src/FeatureManager.php
+++ b/src/FeatureManager.php
@@ -79,7 +79,6 @@ class FeatureManager extends Manager
     {
         return with($this->container['config']->get('pennant.stores.database'), function ($config) {
             return new DatabaseDriver(
-                $this->container['db']->connection($config['connection'] ?? null),
                 $this->container['events'],
                 $config,
                 []


### PR DESCRIPTION
TL;DR uses Illuminate\Support\Facades\DB to create the connection

---

# Reason
The reason behind this pr is when using dynamic databases like on multi-tenant applications often the database name is null and set dynamically depending on the request so getting the db connection out of the container like:
** $this->container['db']->connection($config['connection'] ?? null) ** will always set the connection using the wrong configuration and no the dynamic one

---

# How to Reproduce
on the config/database.php

create a connection like this:

'connections' => [

        'tenant' => [
            'driver' => 'mysql',
            'url' => env('DATABASE_URL'),
            'host' => env('DB_HOST', '127.0.0.1'),
            'port' => env('DB_PORT', '3306'),
            'database' => null, 
            'username' => env('DB_USERNAME', 'forge'),
            'password' => env('DB_PASSWORD', ''),
            'unix_socket' => env('DB_SOCKET', ''),
            'charset' => 'utf8mb4',
            'collation' => 'utf8mb4_unicode_ci',
            'prefix' => '',
            'prefix_indexes' => true,
            'strict' => true,
            'engine' => null,
            'options' => extension_loaded('pdo_mysql') ? array_filter([
                PDO::MYSQL_ATTR_SSL_CA => env('MYSQL_ATTR_SSL_CA'),
                'sticky' => false,
            ]) : [],
        ],
        
        
in order to simulate a multi-tenant app change the config files in any route, request, etc like this:

config([
            'database.connections.tenant.database' => 'any_database',
        ]);
  DB::purge('tenant');
  
  Finally use Laravel pennant as you like and you will notice an error:
  
 ** Call to a member function prepare() on null **

       