### PR TITLE
[1.x] Lazily resolves the database connection

### DIFF
--- a/src/Drivers/DatabaseDriver.php
+++ b/src/Drivers/DatabaseDriver.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Pennant\Drivers;
 
+use Closure;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Database\Connection;
 use Illuminate\Support\Carbon;
@@ -14,11 +15,11 @@ use stdClass;
 class DatabaseDriver implements Driver
 {
     /**
-     * The database connection.
+     * The database connection resolver.
      *
-     * @var \Illuminate\Database\Connection
+     * @var (\Closure(): \Illuminate\Database\Connection)
      */
-    protected $db;
+    protected $connectionResolver;
 
     /**
      * The user configuration.
@@ -51,13 +52,14 @@ class DatabaseDriver implements Driver
     /**
      * Create a new driver instance.
      *
+     * @param  (\Closure(): Illuminate\Database\Connection)  $connectionResolver
      * @param  array{connection?: string|null, table?: string|null}  $config
      * @param  array<string, (callable(mixed $scope): mixed)>  $featureStateResolvers
      * @return void
      */
-    public function __construct(Connection $db, Dispatcher $events, $config, $featureStateResolvers)
+    public function __construct(Closure $connectionResolver, Dispatcher $events, $config, $featureStateResolvers)
     {
-        $this->db = $db;
+        $this->connectionResolver = $connectionResolver;
         $this->events = $events;
         $this->config = $config;
         $this->featureStateResolvers = $featureStateResolvers;
@@ -313,6 +315,6 @@ class DatabaseDriver implements Driver
      */
     protected function newQuery()
     {
-        return $this->db->table($this->config['table'] ?? 'features');
+        return ($this->connectionResolver)()->table($this->config['table'] ?? 'features');
     }
 }

--- a/src/FeatureManager.php
+++ b/src/FeatureManager.php
@@ -77,14 +77,12 @@ class FeatureManager extends Manager
      */
     public function createDatabaseDriver()
     {
-        return with($this->container['config']->get('pennant.stores.database'), function ($config) {
-            return new DatabaseDriver(
-                $this->container['db']->connection($config['connection'] ?? null),
-                $this->container['events'],
-                $config,
-                []
-            );
-        });
+        return new DatabaseDriver(
+            fn () => $this->container['db']->connection($this->container['config']->get('pennant.stores.database.connection')),
+            $this->container['events'],
+            $this->container['config']->get('pennant.stores.database'),
+            []
+        );
     }
 
     /**

--- a/tests/Feature/DatabaseDriverTest.php
+++ b/tests/Feature/DatabaseDriverTest.php
@@ -1167,6 +1167,36 @@ class DatabaseDriverTest extends TestCase
 
         $this->app['config']->set('database.default', 'testing');
     }
+
+    public function test_stores_may_be_configured()
+    {
+        $this->app['config']->set('database.connections.foo_connection', $this->app['config']->get('database.connections.testing'));
+        $this->app['config']->set('database.connections.bar_connection', $this->app['config']->get('database.connections.testing'));
+        $this->app['config']->set('pennant.stores.foo', [
+            'driver' => 'database',
+            'connection' => 'foo_connection',
+            'table' => 'foo_features',
+        ]);
+        $this->app['config']->set('pennant.stores.bar', [
+            'driver' => 'database',
+            'connection' => 'bar_connection',
+            'table' => 'bar_features',
+        ]);
+        $connectionResolver = function () {
+            return $this->newQuery()->connection->getName();
+        };
+        $tableResolver = function () {
+            return $this->newQuery()->from;
+        };
+
+        $driver = Feature::store('foo')->getDriver();
+        $this->assertSame('foo_connection', $connectionResolver->bindTo($driver, $driver)());
+        $this->assertSame('foo_features', $tableResolver->bindTo($driver, $driver)());
+
+        $driver = Feature::store('bar')->getDriver();
+        $this->assertSame('bar_connection', $connectionResolver->bindTo($driver, $driver)());
+        $this->assertSame('bar_features', $tableResolver->bindTo($driver, $driver)());
+    }
 }
 
 class UnregisteredFeature

--- a/tests/Feature/DatabaseDriverTest.php
+++ b/tests/Feature/DatabaseDriverTest.php
@@ -1134,6 +1134,39 @@ class DatabaseDriverTest extends TestCase
         $this->assertNotNull($record->updated_at);
         $this->assertNotNull($record->created_at);
     }
+
+    public function test_it_resolves_configured_database_connection_dynamically()
+    {
+        $this->app['config']->set('database.connections.foo', $this->app['config']->get('database.connections.testing'));
+        $this->app['config']->set('database.connections.bar', $this->app['config']->get('database.connections.testing'));
+        $driver = Feature::store()->getDriver();
+        $connectionResolver = (function () {
+            return $this->newQuery()->connection->getName();
+        })->bindTo($driver, $driver);
+
+        $this->app['config']->set('pennant.stores.database.connection', 'foo');
+        $this->assertSame('foo', $connectionResolver());
+
+        $this->app['config']->set('pennant.stores.database.connection', 'bar');
+        $this->assertSame('bar', $connectionResolver());
+    }
+
+    public function test_it_resolves_default_database_connection_dynamically()
+    {
+        $this->app['config']->set('database.connections.foo', $this->app['config']->get('database.connections.testing'));
+        $driver = Feature::store()->getDriver();
+        $connectionResolver = (function () {
+            return $this->newQuery()->connection->getName();
+        })->bindTo($driver, $driver);
+
+        $this->app['config']->set('database.default', 'testing');
+        $this->assertSame('testing', $connectionResolver());
+
+        $this->app['config']->set('database.default', 'foo');
+        $this->assertSame('foo', $connectionResolver());
+
+        $this->app['config']->set('database.default', 'testing');
+    }
 }
 
 class UnregisteredFeature


### PR DESCRIPTION
This is an alternative to #42. The connection and all configuration is now lazily resolved allowing for better multi-tennant support.

This allows the configuration to be changed at runtime and the correct values will be used within the drivers.

This is technically a breaking change to the DatabaseDriver's constructor signature, however I believe we can take the risk as it is still very early days for the package.

Additionally, this PR fixes an issue where stores were not configurable. Now multiple database stores may exist at once and be configured on an individual basis.