### PR TITLE
Not call whenInactive when it is null

### DIFF
--- a/src/PendingScopedFeatureInteraction.php
+++ b/src/PendingScopedFeatureInteraction.php
@@ -208,7 +208,9 @@ class PendingScopedFeatureInteraction
             return $whenActive($this->value($feature), $this);
         }
 
-        return $whenInactive($this);
+        if ($whenInactive !== null) {
+            return $whenInactive($this);
+        }
     }
 
     /**


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Corrected the `whenInactive` closure call in the `when` method, so that it is called when not null.