### PR TITLE
Adds ability to define before callbacks

### DIFF
--- a/src/Drivers/Decorator.php
+++ b/src/Drivers/Decorator.php
@@ -76,6 +76,7 @@ class Decorator implements DriverContract
      * @param  string  $name
      * @param  \Laravel\Pennant\Contracts\Driver  $driver
      * @param  (callable(): mixed)  $defaultScopeResolver
+     * @param  array  $beforeCallbacks
      * @param  \Illuminate\Contracts\Container\Container  $container
      * @param  \Illuminate\Support\Collection<int, array{ feature: string, scope: mixed, value: mixed }>  $cache
      */

--- a/src/Drivers/Decorator.php
+++ b/src/Drivers/Decorator.php
@@ -159,14 +159,6 @@ class Decorator implements DriverContract
      */
     protected function resolve($feature, $resolver, $scope)
     {
-        $result = $this->callBeforeCallbacks(
-            $feature, $scope
-        );
-
-        if (! is_null($result)) {
-            return $result;
-        }
-
         $value = $resolver($scope);
 
         $value = $value instanceof Lottery ? $value() : $value;
@@ -276,6 +268,14 @@ class Decorator implements DriverContract
         $feature = $this->resolveFeature($feature);
 
         $scope = $this->resolveScope($scope);
+
+        $result = $this->callBeforeCallbacks(
+            $feature, $scope
+        );
+
+        if (! is_null($result)) {
+            return $result;
+        }
 
         $item = $this->cache
             ->whereStrict('scope', $scope)

--- a/src/Feature.php
+++ b/src/Feature.php
@@ -18,6 +18,7 @@ use RuntimeException;
  * @method static \Laravel\Pennant\FeatureManager forgetDriver(array|string|null $name = null)
  * @method static \Laravel\Pennant\FeatureManager forgetDrivers()
  * @method static \Laravel\Pennant\FeatureManager extend(string $driver, \Closure $callback)
+ * @method static \Laravel\Pennant\FeatureManager before(callable $callable)
  * @method static void setContainer(\Illuminate\Container\Container $container)
  * @method static void discover(string $namespace = 'App\\Features', string|null $path = null)
  * @method static void define(string $feature, mixed $resolver = null)

--- a/src/FeatureManager.php
+++ b/src/FeatureManager.php
@@ -45,6 +45,13 @@ class FeatureManager
     protected $defaultScopeResolver;
 
     /**
+     * All of the registered before callbacks.
+     *
+     * @var array
+     */
+    protected $beforeCallbacks = [];
+
+    /**
      * Create a new Pennant manager instance.
      *
      * @return void
@@ -125,6 +132,7 @@ class FeatureManager
             $name,
             $driver,
             $this->defaultScopeResolver($name),
+            $this->beforeCallbacks,
             $this->container,
             new Collection
         );
@@ -281,6 +289,19 @@ class FeatureManager
     public function extend($driver, Closure $callback)
     {
         $this->customCreators[$driver] = $callback->bindTo($this, $this);
+
+        return $this;
+    }
+
+    /**
+     * Register a callback to run before the features are resolved.
+     *
+     * @param  callable  $callback
+     * @return $this
+     */
+    public function before(callable $callback)
+    {
+        $this->beforeCallbacks[] = $callback;
 
         return $this;
     }

--- a/tests/Feature/FeatureManagerTest.php
+++ b/tests/Feature/FeatureManagerTest.php
@@ -80,4 +80,15 @@ class FeatureManagerTest extends TestCase
         $this->assertTrue(Feature::forSession()->active('my-feature'));
         $this->assertFalse(Feature::for('default-scope')->active('my-feature'));
     }
+
+    public function test_it_can_return_before_callbacks()
+    {
+        Feature::before(fn () => false);
+
+        Feature::define('foo', true);
+
+        Feature::load('foo');
+
+        $this->assertFalse(Feature::active('foo'));
+    }
 }


### PR DESCRIPTION
Similar to the Gate, this PR adds the ability to add some before callbacks before the feature value is resolved.

This PR is in response to #52 to allow dynamic features when needed. 

```
Feature::before(function($feature, $scope) {
  if ($scope instanceof User && $scope->isAdministrator()) {
    return true;
  }
});
```