### PR TITLE
[1.x] Provide hook to use morph map while serializing models

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Laravel Pennant is a simple, lightweight library for managing feature flags.
 
 ## Official Documentation
 
-Documentation for Laravel Pennant can be found on the [Laravel website](https://laravel.com/docs/10.x/pennant).
+Documentation for Laravel Pennant can be found on the [Laravel website](https://laravel.com/docs/pennant).
 
 ## Contributing
 

--- a/src/Feature.php
+++ b/src/Feature.php
@@ -2,9 +2,7 @@
 
 namespace Laravel\Pennant;
 
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Facade;
-use RuntimeException;
 
 /**
  * @method static \Laravel\Pennant\Drivers\Decorator store(string|null $store = null)
@@ -61,22 +59,5 @@ class Feature extends Facade
     protected static function getFacadeAccessor()
     {
         return FeatureManager::class;
-    }
-
-    /**
-     * Serialize the given scope for storage.
-     *
-     * @param  mixed  $scope
-     * @return string|null
-     */
-    public static function serializeScope($scope)
-    {
-        return match (true) {
-            $scope === null => '__laravel_null',
-            is_string($scope) => $scope,
-            is_numeric($scope) => (string) $scope,
-            $scope instanceof Model => $scope::class.'|'.$scope->getKey(),
-            default => throw new RuntimeException('Unable to serialize the feature scope to a string. You should implement the FeatureScopeable contract.')
-        };
     }
 }

--- a/src/FeatureManager.php
+++ b/src/FeatureManager.php
@@ -5,7 +5,6 @@ namespace Laravel\Pennant;
 use Closure;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Manager;
 use InvalidArgumentException;

--- a/src/FeatureManager.php
+++ b/src/FeatureManager.php
@@ -4,12 +4,15 @@ namespace Laravel\Pennant;
 
 use Closure;
 use Illuminate\Contracts\Container\Container;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Manager;
 use InvalidArgumentException;
 use Laravel\Pennant\Drivers\ArrayDriver;
 use Laravel\Pennant\Drivers\DatabaseDriver;
 use Laravel\Pennant\Drivers\Decorator;
+use RuntimeException;
 
 /**
  * @mixin \Laravel\Pennant\Drivers\Decorator
@@ -43,6 +46,13 @@ class FeatureManager
      * @var (callable(string): mixed)|null
      */
     protected $defaultScopeResolver;
+
+    /**
+     * Determine if the morph map should be used when serializing.
+     *
+     * @var bool
+     */
+    protected $useMorphMap = false;
 
     /**
      * Create a new Pennant manager instance.
@@ -163,6 +173,36 @@ class FeatureManager
             $config,
             []
         );
+    }
+
+    /**
+     * Serialize the given scope for storage.
+     *
+     * @param  mixed  $scope
+     * @return string|null
+     */
+    public function serializeScope($scope)
+    {
+        return match (true) {
+            $scope === null => '__laravel_null',
+            is_string($scope) => $scope,
+            is_numeric($scope) => (string) $scope,
+            $scope instanceof Model && $this->useMorphMap => $scope->getMorphClass().'|'.$scope->getKey(),
+            $scope instanceof Model && ! $this->useMorphMap => $scope::class.'|'.$scope->getKey(),
+            default => throw new RuntimeException('Unable to serialize the feature scope to a string. You should implement the FeatureScopeable contract.')
+        };
+    }
+
+    /**
+     * Use the morph map when serializing.
+     *
+     * @return $this
+     */
+    public function useMorphMap($value = true)
+    {
+        $this->useMorphMap = $value;
+
+        return $this;
     }
 
     /**

--- a/tests/Feature/DatabaseDriverTest.php
+++ b/tests/Feature/DatabaseDriverTest.php
@@ -1248,7 +1248,7 @@ class DatabaseDriverTest extends TestCase
     {
         $model = new User(['id' => 6]);
         Relation::morphMap([
-            'user-morph' => $model::class ,
+            'user-morph' => $model::class,
         ]);
         $scopes = [];
         Feature::define('foo', fn () => true);

--- a/tests/Feature/DatabaseDriverTest.php
+++ b/tests/Feature/DatabaseDriverTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature;
 
+use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Config;
@@ -1241,6 +1242,25 @@ class DatabaseDriverTest extends TestCase
             return $event->feature === 'foo'
                 && $event->scope === 'tim';
         });
+    }
+
+    public function test_it_can_use_eloquent_morph_map_for_scope_serialization()
+    {
+        $model = new User(['id' => 6]);
+        Relation::morphMap([
+            'user-morph' => $model::class ,
+        ]);
+        $scopes = [];
+        Feature::define('foo', fn () => true);
+
+        Feature::useMorphMap();
+        Feature::for($model)->active('foo');
+
+        $this->assertDatabaseHas('features', [
+            'name' => 'foo',
+            'scope' => 'user-morph|6',
+            'value' => 'true',
+        ]);
     }
 }
 


### PR DESCRIPTION
This PR introduces a hook to use morphMap values when serializing models.

In a service provider:

```php
Feature::useMorphMap();

Feature::define('foo', /* ... */);
```

fixes #63

Documented: https://github.com/laravel/docs/pull/8867