### PR TITLE
Supports scope in blade directive

### DIFF
--- a/src/PennantServiceProvider.php
+++ b/src/PennantServiceProvider.php
@@ -36,7 +36,11 @@ class PennantServiceProvider extends ServiceProvider
         }
 
         $this->callAfterResolving('blade.compiler', function ($blade) {
-            $blade->if('feature', function ($feature, $value = null) {
+            $blade->if('feature', function ($feature, $value = null, $scope = null) {
+                if ($feature && $scope) {
+                    return Feature::for($scope)->active($feature);
+                }
+
                 if (func_num_args() === 2) {
                     return Feature::value($feature) === $value;
                 }


### PR DESCRIPTION
This PR modifies the boot method in PennantServiceProvider to allow feature scope support in the feature Blade directive.

Original:

```
$this->callAfterResolving('blade.compiler', function ($blade) {
    $blade->if('feature', function ($feature, $value = null) {
        if (func_num_args() === 2) {
            return Feature::value($feature) === $value;
        }

        return Feature::active($feature);
    });
});
```

Proposed:

```
$this->callAfterResolving('blade.compiler', function ($blade) {
    $blade->if('feature', function ($feature, $value = null, $scope = null) {
        if ($feature && $scope) {
            return Feature::for($scope)->active($feature);
        }

        if (func_num_args() === 2) {
            return Feature::value($feature) === $value;
        }

        return Feature::active($feature);
    });
});
```

Which enables you to specify a scope from within Blade components:

```
@feature($feature, null, $scope)
    <p>Scoped.</p>
@endfeature
```

This change is backward-compatible and does not affect existing functionality as it just extends the current implementation with an optional parameter. Users can still use the feature directive without passing a scope.