### PR TITLE
[1.x] Added "all" method to "EnsureFeaturesAreActive" middleware.

### DIFF
--- a/src/Middleware/EnsureFeaturesAreActive.php
+++ b/src/Middleware/EnsureFeaturesAreActive.php
@@ -33,4 +33,9 @@ class EnsureFeaturesAreActive
     {
         static::$respondUsing = $callback;
     }
+
+    public static function all(string ...$features): string
+    {
+        return static::class.':'.implode(',', $features);
+    }
 }

--- a/src/Middleware/EnsureFeaturesAreActive.php
+++ b/src/Middleware/EnsureFeaturesAreActive.php
@@ -34,6 +34,9 @@ class EnsureFeaturesAreActive
         static::$respondUsing = $callback;
     }
 
+    /**
+     * Specify the features for the middleware.
+     */
     public static function all(string ...$features): string
     {
         return static::class.':'.implode(',', $features);

--- a/src/Middleware/EnsureFeaturesAreActive.php
+++ b/src/Middleware/EnsureFeaturesAreActive.php
@@ -27,18 +27,18 @@ class EnsureFeaturesAreActive
     }
 
     /**
-     * Specify a callback that should be used to generate responses for failed feature checks.
-     */
-    public static function whenInactive(?Closure $callback): void
-    {
-        static::$respondUsing = $callback;
-    }
-
-    /**
      * Specify the features for the middleware.
      */
     public static function all(string ...$features): string
     {
         return static::class.':'.implode(',', $features);
+    }
+
+    /**
+     * Specify a callback that should be used to generate responses for failed feature checks.
+     */
+    public static function whenInactive(?Closure $callback): void
+    {
+        static::$respondUsing = $callback;
     }
 }

--- a/tests/Feature/FeatureMiddlewareTest.php
+++ b/tests/Feature/FeatureMiddlewareTest.php
@@ -98,6 +98,14 @@ class FeatureMiddlewareTest extends TestCase
         );
     }
 
+    public function test_middleware_string_can_be_returned(): void
+    {
+        $this->assertEquals(
+            'Laravel\Pennant\Middleware\EnsureFeaturesAreActive:test,another',
+            EnsureFeaturesAreActive::all('test', 'another'),
+        );
+    }
+
     protected function createRequest(string $uri, string $method): Request
     {
         $request = SymfonyRequest::create(


### PR DESCRIPTION
Hey! This PR is only a small one and proposes a tiny piece of syntactic sugar for the `EnsureFeaturesAreActive` middleware.

At the moment, the docs show you can use Pennant's middleware on a route like so:

```php
Route::get('/api/servers', function () {
    // ...
})->middleware(['features:new-api,servers-api']);
```

This PR proposes a new `all` method that would allow you to change the route definition to look like so:

```php
Route::get('/api/servers', function () {
    // ...
})->middleware([EnsureFeaturesAreActive::all('new-api', 'servers-api')]);
```

Or if we're using class-based features, something like:

```php
Route::get('/api/servers', function () {
    // ...
})->middleware([EnsureFeaturesAreActive::all(NewApi::class, ServerApi::class)]);
```


Under the hood, the `all` method is just outputting the middleware in the string format like in the first example.

My reasoning for proposing this new method is that I like to avoid using free-form strings as much as possible. I have a habit of making typos that take me ages to track down haha! In fact, I even made a mistake when using the first approach because I registered the middleware as `features` and tried referencing it in my routes as `feature`. It took me a few moments to realise I'd missed off the `s` 🤦‍♂️

By using this new method, I think it'd also remove the need to register the `features` middleware alias in the `app/Http/Kernel.php` too.

If this is something you think might be helpful to other developers, please give me a shout if there's anything you might want my to change 😄