### PR TITLE
Fix tests that don't run

### DIFF
--- a/tests/Feature/FeatureMiddlewareTest.php
+++ b/tests/Feature/FeatureMiddlewareTest.php
@@ -54,6 +54,8 @@ class FeatureMiddlewareTest extends TestCase
 
     public function it_throws_an_exception_if_one_of_the_features_is_not_active(): void
     {
+        dd("I won't be run");
+
         $this->expectException(HttpException::class);
         $this->assertFalse(Feature::active('test'));
 
@@ -66,6 +68,8 @@ class FeatureMiddlewareTest extends TestCase
 
     public function it_allows_custom_responses(): void
     {
+        dd("I won't be run");
+
         $this->assertFalse(Feature::active('test'));
 
         EnsureFeaturesAreActive::whenInactive(fn (Request $request, array $features) => 'test-response');
@@ -83,6 +87,8 @@ class FeatureMiddlewareTest extends TestCase
 
     public function it_passes_if_all_features_are_enabled(): void
     {
+        dd("I won't be run");
+
         Feature::define('test', true);
         Feature::define('another', true);
 

--- a/tests/Feature/FeatureMiddlewareTest.php
+++ b/tests/Feature/FeatureMiddlewareTest.php
@@ -52,10 +52,8 @@ class FeatureMiddlewareTest extends TestCase
         );
     }
 
-    public function it_throws_an_exception_if_one_of_the_features_is_not_active(): void
+    public function test_it_throws_an_exception_if_one_of_the_features_is_not_active(): void
     {
-        dd("I won't be run");
-
         $this->expectException(HttpException::class);
         $this->assertFalse(Feature::active('test'));
 
@@ -66,10 +64,8 @@ class FeatureMiddlewareTest extends TestCase
         );
     }
 
-    public function it_allows_custom_responses(): void
+    public function test_it_allows_custom_responses(): void
     {
-        dd("I won't be run");
-
         $this->assertFalse(Feature::active('test'));
 
         EnsureFeaturesAreActive::whenInactive(fn (Request $request, array $features) => 'test-response');
@@ -85,10 +81,8 @@ class FeatureMiddlewareTest extends TestCase
         EnsureFeaturesAreActive::whenInactive(null);
     }
 
-    public function it_passes_if_all_features_are_enabled(): void
+    public function test_it_passes_if_all_features_are_enabled(): void
     {
-        dd("I won't be run");
-
         Feature::define('test', true);
         Feature::define('another', true);
 


### PR DESCRIPTION
Hey! I'm just making a PR to fix some tests that I _think_ aren't ever run when using `vendor/bin/phpunit` (like what's done in CI). I noticed these when working on #70.

The first commit in this PR should cause the tests to fail but I think they'll pass. I've added `dd("I won't be run");` to the beginning of the 3 tests that aren't ever run to show this.

Once the tests have passed, I'll remove the `dd` and update them so they're all run as intended.

Hopefully, this is all correct, but apologies if I've done anything wrong 😄
