### PR TITLE
[1.x] Rename to match framework

### DIFF
--- a/src/Middleware/EnsureFeaturesAreActive.php
+++ b/src/Middleware/EnsureFeaturesAreActive.php
@@ -29,7 +29,7 @@ class EnsureFeaturesAreActive
     /**
      * Specify the features for the middleware.
      */
-    public static function all(string ...$features): string
+    public static function using(string ...$features): string
     {
         return static::class.':'.implode(',', $features);
     }

--- a/tests/Feature/FeatureMiddlewareTest.php
+++ b/tests/Feature/FeatureMiddlewareTest.php
@@ -102,7 +102,7 @@ class FeatureMiddlewareTest extends TestCase
     {
         $this->assertEquals(
             'Laravel\Pennant\Middleware\EnsureFeaturesAreActive:test,another',
-            EnsureFeaturesAreActive::all('test', 'another'),
+            EnsureFeaturesAreActive::using('test', 'another'),
         );
     }
 


### PR DESCRIPTION
Renaming the new, lovely, static helper method to match those found in the framework for consistency.

// cc @ash-jc-allen