### PR TITLE
Add Redis Driver

### DIFF
--- a/config/pennant.php
+++ b/config/pennant.php
@@ -40,5 +40,10 @@ return [
             'table' => 'features',
         ],
 
+        'redis' => [
+            'driver' => 'redis',
+            'connection' => 'default',
+        ],
+
     ],
 ];

--- a/src/Drivers/RedisFeatureDriver.php
+++ b/src/Drivers/RedisFeatureDriver.php
@@ -1,0 +1,191 @@
+<?php
+
+namespace Laravel\Pennant\Drivers;
+
+use Laravel\Pennant\Contracts\Driver;
+use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Redis\RedisManager;
+use Illuminate\Support\Collection;
+use Laravel\Pennant\Events\UnknownFeatureResolved;
+use Laravel\Pennant\Feature;
+use stdClass;
+
+class RedisFeatureDriver implements Driver
+{
+
+    /**
+     * The sentinel value for unknown features.
+     *
+     * @var stdClass
+     */
+    protected stdClass $unknownFeatureValue;
+
+    /**
+     * The prefix for the feature flags.
+     * @var string
+     */
+    private string $prefix = 'feature';
+
+    /**
+     * Create a new driver instance.
+     * @param RedisManager $redis
+     * @param Dispatcher $events
+     * @param array<string, (callable(mixed $scope): mixed)> $featureStateResolvers
+     */
+    public function __construct(private readonly RedisManager $redis, private readonly Dispatcher $events, protected array $featureStateResolvers)
+    {
+        $this->unknownFeatureValue = new stdClass;
+    }
+
+
+    /**
+     * Define an initial feature flag state resolver.
+     * @param string $feature
+     * @param (callable(mixed $scope): mixed) $resolver
+     * @return void
+     */
+    public function define(string $feature, callable $resolver): void
+    {
+
+        $this->featureStateResolvers[$feature] = $resolver;
+    }
+
+
+    /**
+     * Define the names of all defined features.
+     * @return array<string>
+     */
+    public function defined(): array
+    {
+
+        return array_keys($this->featureStateResolvers);
+    }
+
+    /**
+     * Get multiple feature flag values.
+     *
+     * @param array<string, array<int, mixed>> $features
+     * @return array<string, array<int, mixed>>
+     */
+    public function getAll(array $features): array
+    {
+
+        return Collection::make($features)
+            ->map(fn($scopes, $feature) => Collection::make($scopes)
+                ->map(fn($scope) => $this->get($feature, $scope))
+                ->all())
+            ->all();
+
+    }
+
+
+    /**
+     * Retrieve a feature flag's value.
+     * @param string $feature
+     * @param mixed $scope
+     * @return mixed
+     */
+    public function get(string $feature, mixed $scope): mixed
+    {
+
+        $scopeKey = Feature::serializeScope($scope);
+
+        $result = $this->redis->command('HGET', ["$this->prefix:$feature", $scopeKey]);
+        if ($result) {
+            return $result;
+        }
+
+
+        return
+            with($this->resolveValue($feature, $scope), function ($value) use ($feature, $scopeKey) {
+                if ($value === $this->unknownFeatureValue) {
+                    return false;
+                }
+
+                $this->set($feature, $scopeKey, $value);
+
+                return $value;
+            });
+    }
+
+    /**
+     * Determine the initial value for a given feature and scope.
+     * @param $feature
+     * @param $scope
+     * @return mixed
+     */
+    protected function resolveValue($feature, $scope)
+    {
+
+        if (!array_key_exists($feature, $this->featureStateResolvers)) {
+            $this->events->dispatch(new UnknownFeatureResolved($feature, $scope));
+
+            return $this->unknownFeatureValue;
+        }
+
+        return $this->featureStateResolvers[$feature]($scope);
+    }
+
+
+    /**
+     * Set a feature flag's value.
+     * @param string $feature
+     * @param mixed $scope
+     * @param mixed $value
+     * @return void
+     */
+    public function set(string $feature, mixed $scope, mixed $value): void
+    {
+        $this->redis->command('HSET', ["$this->prefix:$feature", Feature::serializeScope($scope), $value]);
+    }
+
+
+    /**
+     * Set a feature flag's value for all scopes.
+     * @param string $feature
+     * @param mixed $value
+     * @return void
+     */
+    public function setForAllScopes(string $feature, mixed $value): void
+    {
+        $this->redis->command('HMSET', ["$this->prefix:$feature", $value]);
+    }
+
+
+    /**
+     * Delete a feature flag's value.
+     * @param string $feature
+     * @param mixed $scope
+     * @return void
+     */
+    public function delete(string $feature, mixed $scope): void
+    {
+        $this->redis->command('HDEL', ["$this->prefix:$feature", Feature::serializeScope($scope)]);
+    }
+
+
+    /**
+     * Purge the given feature from storage.
+     * @param array|null $features
+     * @return void
+     */
+    public function purge(?array $features): void
+    {
+
+        if ($features === null) {
+            $ds = $this->redis->command('KEYS', ["$this->prefix:*"]);
+            $ds = array_map(fn($d) => explode($this->prefix, $d)[1], $ds);
+
+            $ds = array_map(fn($d) => $this->prefix . $d, $ds);
+
+            foreach ($ds as $d) {
+                $this->redis->command('DEL', [$d]);
+            }
+
+        } else {
+            foreach ($features as $feature) {
+                $this->redis->command('DEL', ["$this->prefix:$feature"]);
+            }
+        }
+    }
+}

--- a/src/FeatureManager.php
+++ b/src/FeatureManager.php
@@ -10,6 +10,7 @@ use InvalidArgumentException;
 use Laravel\Pennant\Drivers\ArrayDriver;
 use Laravel\Pennant\Drivers\DatabaseDriver;
 use Laravel\Pennant\Drivers\Decorator;
+use Laravel\Pennant\Drivers\RedisFeatureDriver;
 use RuntimeException;
 
 /**
@@ -169,6 +170,20 @@ class FeatureManager
             $this->container['db']->connection($config['connection'] ?? null),
             $this->container['events'],
             $config,
+            []
+        );
+    }
+
+    /**
+     * Create an instance of the redis driver.
+     *
+     * @return \Laravel\Pennant\Drivers\RedisFeatureDriver
+     */
+    public function createRedisDriver()
+    {
+        return new RedisFeatureDriver(
+            $this->container['redis'],
+            $this->container['events'],
             []
         );
     }


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
Considering the necessity of employing storage other than arrays or databases, I took the liberty of crafting a driver to provide native support for Redis.

The advantage lies in not being confined to a single Laravel instance or the database, which already contends with its challenges of overload.

This minor alteration is a replica of the database driver, with adaptations for writing and reading Hash in Redis.