### PR TITLE
[1.x] Respect configuration changes

### DIFF
--- a/src/FeatureManager.php
+++ b/src/FeatureManager.php
@@ -123,7 +123,7 @@ class FeatureManager
             $driverMethod = 'create'.ucfirst($config['driver']).'Driver';
 
             if (method_exists($this, $driverMethod)) {
-                $driver = $this->{$driverMethod}($config);
+                $driver = $this->{$driverMethod}($config, $name);
             } else {
                 throw new InvalidArgumentException("Driver [{$config['driver']}] is not supported.");
             }
@@ -163,12 +163,13 @@ class FeatureManager
      *
      * @return \Laravel\Pennant\Drivers\DatabaseDriver
      */
-    public function createDatabaseDriver(array $config)
+    public function createDatabaseDriver(array $config, string $name)
     {
         return new DatabaseDriver(
-            $this->container['db']->connection($config['connection'] ?? null),
+            $this->container['db'],
             $this->container['events'],
-            $config,
+            $this->container['config'],
+            $name,
             []
         );
     }

--- a/tests/Feature/DatabaseDriverTest.php
+++ b/tests/Feature/DatabaseDriverTest.php
@@ -1273,7 +1273,7 @@ class DatabaseDriverTest extends TestCase
         Config::set('pennant.stores.database.connection', 'xxxx');
 
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage("Database connection [xxxx] not configured.");
+        $this->expectExceptionMessage('Database connection [xxxx] not configured.');
         Feature::store('database')->active('feature-name');
     }
 }

--- a/tests/Feature/DatabaseDriverTest.php
+++ b/tests/Feature/DatabaseDriverTest.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Event;
+use InvalidArgumentException;
 use Laravel\Pennant\Contracts\FeatureScopeable;
 use Laravel\Pennant\Events\AllFeaturesPurged;
 use Laravel\Pennant\Events\DynamicallyRegisteringFeatureClass;
@@ -1260,6 +1261,20 @@ class DatabaseDriverTest extends TestCase
             'scope' => 'user-morph|6',
             'value' => 'true',
         ]);
+    }
+
+    public function test_it_respects_updated_connection_configuration()
+    {
+        Feature::flushCache();
+        Config::set('pennant.stores.database.connection', null);
+        Feature::store('database')->active('feature-name');
+
+        Feature::flushCache();
+        Config::set('pennant.stores.database.connection', 'xxxx');
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("Database connection [xxxx] not configured.");
+        Feature::store('database')->active('feature-name');
     }
 }
 


### PR DESCRIPTION
fixes https://github.com/laravel/pennant/issues/80

Pennant's `DatabaseDriver` does not currently respect changes to configuration. It also holds onto a `Illuminate\Database\Connection` instance. This is problematic in Octane, queue worker, and testsuite scenarios.

This PR ensures that changes to configuration, such as `Config::set('pennant.stores.database.connection', 'foo')`, are respected. This most likely happens in testsuites when running in parallel.

It also stops the `DatabaseDriver` from holding on to a DB connection instance. The database manager is now injected and the connection is always resolved fresh.

This is technically a breaking change for anyone extending the `DatabaseDriver` as the `__construct` signature has changed and the injected `$db` type has changed. I think the likelihood of extending that is pretty slim and this is a worthwhile break to fix the bug.