### PR TITLE
[1.x] Ensure cache holds serialized values only

### DIFF
--- a/src/Drivers/Decorator.php
+++ b/src/Drivers/Decorator.php
@@ -20,6 +20,7 @@ use Laravel\Pennant\Events\FeaturesPurged;
 use Laravel\Pennant\Events\FeatureUpdated;
 use Laravel\Pennant\Events\FeatureUpdatedForAllScopes;
 use Laravel\Pennant\Events\UnexpectedNullScopeEncountered;
+use Laravel\Pennant\Feature;
 use Laravel\Pennant\LazilyResolvedFeature;
 use Laravel\Pennant\PendingScopedFeatureInteraction;
 use ReflectionFunction;
@@ -267,7 +268,7 @@ class Decorator implements DriverContract
         $scope = $this->resolveScope($scope);
 
         $item = $this->cache
-            ->whereStrict('scope', $scope)
+            ->whereStrict('scope', Feature::serializeScope($scope))
             ->whereStrict('feature', $feature)
             ->first();
 
@@ -466,6 +467,8 @@ class Decorator implements DriverContract
      */
     protected function isCached($feature, $scope)
     {
+        $scope = Feature::serializeScope($scope);
+
         return $this->cache->search(
             fn ($item) => $item['feature'] === $feature && $item['scope'] === $scope
         ) !== false;
@@ -481,6 +484,8 @@ class Decorator implements DriverContract
      */
     protected function putInCache($feature, $scope, $value)
     {
+        $scope = Feature::serializeScope($scope);
+
         $position = $this->cache->search(
             fn ($item) => $item['feature'] === $feature && $item['scope'] === $scope
         );
@@ -501,6 +506,8 @@ class Decorator implements DriverContract
      */
     protected function removeFromCache($feature, $scope)
     {
+        $scope = Feature::serializeScope($scope);
+
         $position = $this->cache->search(
             fn ($item) => $item['feature'] === $feature && $item['scope'] === $scope
         );

--- a/tests/Feature/ArrayDriverTest.php
+++ b/tests/Feature/ArrayDriverTest.php
@@ -1103,7 +1103,8 @@ class ArrayDriverTest extends TestCase
 
     public function test_it_caches_by_identifier_for_feature_scopable_objects()
     {
-        $factory = fn () => new class implements FeatureScopeable {
+        $factory = fn () => new class implements FeatureScopeable
+        {
             public function toFeatureIdentifier(string $driver): mixed
             {
                 return 'foo';
@@ -1143,7 +1144,6 @@ class ArrayDriverTest extends TestCase
         $this->assertEquals(4, Feature::for($user1)->value('myflag'));
         $this->assertEquals(4, Feature::for($user2)->value('myflag'));
     }
-
 }
 
 class MyFeature

--- a/tests/Feature/ArrayDriverTest.php
+++ b/tests/Feature/ArrayDriverTest.php
@@ -1100,6 +1100,50 @@ class ArrayDriverTest extends TestCase
                 && $event->scope === 'tim';
         });
     }
+
+    public function test_it_caches_by_identifier_for_feature_scopable_objects()
+    {
+        $factory = fn () => new class implements FeatureScopeable {
+            public function toFeatureIdentifier(string $driver): mixed
+            {
+                return 'foo';
+            }
+        };
+
+        Feature::for($object = $factory())->activate('foo');
+
+        $this->assertTrue(Feature::for($object)->active('foo'));
+        $this->assertTrue(Feature::for($factory())->active('foo'));
+    }
+
+    public function test_it_caches_by_identification_for_other_objects()
+    {
+        $factory = fn ($name) => new User(['id' => 123, 'name' => $name]);
+
+        Feature::for($object = $factory('Tim'))->activate('foo');
+
+        $this->assertTrue(Feature::for($object)->active('foo'));
+        $this->assertTrue(Feature::for($factory('Taylor'))->active('foo'));
+    }
+
+    public function test_caching_of_features(): void
+    {
+        $factory = fn () => new User(['id' => 123]);
+        $user1 = $factory();
+        $user2 = $factory();
+
+        Feature::for($user1)->activate('myflag', 2);
+        $this->assertEquals(2, Feature::for($user1)->active('myflag'));
+
+        Feature::for($user1)->activate('myflag', 3);
+        $this->assertEquals(3, Feature::for($user1)->active('myflag'));
+
+        Feature::for($user2)->activate('myflag', 4);
+
+        $this->assertEquals(4, Feature::for($user1)->value('myflag'));
+        $this->assertEquals(4, Feature::for($user2)->value('myflag'));
+    }
+
 }
 
 class MyFeature


### PR DESCRIPTION
fixes https://github.com/laravel/pennant/issues/82

The cache is currently holding onto scope object, which is a potential memory issue as all scope will now stay in memory until the end of the request.

It also means that the cache behaves unexpectedly for eloquent models when different instances of the same record are used, e.g., 

```php
Feature::for(User::find(123))->activate('foo');

Feature::for(User::find(123))->activate('foo');
```

This fixes the memory issue and model reference issues by making sure the scope is serialized before it enters the cache.