### PR TITLE
Ability to map feature names

### DIFF
--- a/src/Drivers/Decorator.php
+++ b/src/Drivers/Decorator.php
@@ -410,6 +410,10 @@ class Decorator implements DriverContract
      */
     protected function resolveFeature($feature)
     {
+        if (isset(Feature::getNameMap()[$feature])) {
+            $feature = Feature::getNameMap()[$feature];
+        }
+
         return $this->shouldDynamicallyDefine($feature)
             ? $this->ensureDynamicFeatureIsDefined($feature)
             : $feature;

--- a/src/FeatureManager.php
+++ b/src/FeatureManager.php
@@ -53,6 +53,13 @@ class FeatureManager
     protected $useMorphMap = false;
 
     /**
+     * The feature names should be mapped to their respective names.
+     *
+     * @var array
+     */
+    protected $nameMap = []; 
+
+    /**
      * Create a new Pennant manager instance.
      *
      * @return void
@@ -203,6 +210,29 @@ class FeatureManager
         $this->useMorphMap = $value;
 
         return $this;
+    }
+
+    /**
+     * The feature names should be mapped to their respective names.
+     *
+     * @param  array  $names
+     * @return $this
+     */
+    public function enforceNameMap($names = [])
+    {
+        $this->nameMap = $names;
+
+        return $this;
+    }
+
+    /**
+     * Get the feature names map.
+     *
+     * @return array
+     */
+    public function getNameMap()
+    {
+        return array_flip($this->nameMap);
     }
 
     /**

--- a/tests/Feature/DatabaseDriverTest.php
+++ b/tests/Feature/DatabaseDriverTest.php
@@ -20,6 +20,7 @@ use Laravel\Pennant\Events\FeatureUpdatedForAllScopes;
 use Laravel\Pennant\Events\UnknownFeatureResolved;
 use Laravel\Pennant\Feature;
 use Tests\TestCase;
+use Workbench\App\Features\NewApi;
 use Workbench\App\Models\User;
 use Workbench\Database\Factories\UserFactory;
 
@@ -1275,6 +1276,20 @@ class DatabaseDriverTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Database connection [xxxx] not configured.');
         Feature::store('database')->active('feature-name');
+    }
+
+    public function test_it_can_use_name_map()
+    {
+        Feature::define('foo', fn () => true);
+        Feature::enforceNameMap([
+            'foo' => NewApi::class,
+        ]);
+        Feature::active('foo');
+
+        $this->assertDatabaseHas('features', [
+            'name' => 'foo',
+            'value' => 'true',
+        ]);
     }
 }
 


### PR DESCRIPTION
This PR adds the ability to map feature names to other names. 

This introduces a new method, `Feature::enforceNameMap()`, which provides a customized string that will get saved to the database. This allows for easy refactoring of class based features and shorter strings in the `name` column.

```php
Feature::enforceNameMap([
    'admin' => AdministrationFeature::class,
    'old-feature' => NewFeature::class,
]);
