### PR TITLE
[1.x] Add ability to prune undefined features

### DIFF
--- a/src/Commands/PruneCommand.php
+++ b/src/Commands/PruneCommand.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Laravel\Pennant\Commands;
+
+use Illuminate\Console\Command;
+use Laravel\Pennant\FeatureManager;
+
+class PruneCommand extends Command
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $signature = 'pennant:prune
+                            {--store= : The store to purge the features from}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Remove undefined Pennant features from storage';
+
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     */
+    public function handle(FeatureManager $manager)
+    {
+        $manager->store($this->option('store'))->prune();
+
+        $this->components->info('Features successfully pruned from storage.');
+
+        return self::SUCCESS;
+    }
+}

--- a/src/Contracts/Driver.php
+++ b/src/Contracts/Driver.php
@@ -50,4 +50,9 @@ interface Driver
      * Purge the given features from storage.
      */
     public function purge(?array $features): void;
+
+    /**
+     * Prune undefined features from storage.
+     */
+    public function prune(): void;
 }

--- a/src/Drivers/ArrayDriver.php
+++ b/src/Drivers/ArrayDriver.php
@@ -208,4 +208,15 @@ class ArrayDriver implements Driver
     {
         $this->resolvedFeatureStates = [];
     }
+
+    public function prune(): void
+    {
+        foreach ($this->resolvedFeatureStates as $feature => $scopes) {
+            if (in_array($feature, $this->defined())) {
+                continue;
+            }
+
+            unset($this->resolvedFeatureStates[$feature]);
+        }
+    }
 }

--- a/src/Drivers/DatabaseDriver.php
+++ b/src/Drivers/DatabaseDriver.php
@@ -338,4 +338,14 @@ class DatabaseDriver implements Driver
             $this->config->get("pennant.stores.{$this->name}.connection") ?? null
         );
     }
+
+    /**
+     * Prune undefined features from storage.
+     */
+    public function prune(): void
+    {
+        $this->newQuery()
+            ->whereNotIn('name', $this->defined())
+            ->delete();
+    }
 }

--- a/src/Drivers/Decorator.php
+++ b/src/Drivers/Decorator.php
@@ -578,4 +578,12 @@ class Decorator implements DriverContract
             }
         })->{$name}(...$parameters);
     }
+
+    /**
+     * Prune undefined features from storage.
+     */
+    public function prune(): void
+    {
+        $this->driver->prune();
+    }
 }

--- a/src/Feature.php
+++ b/src/Feature.php
@@ -48,6 +48,7 @@ use Illuminate\Support\Facades\Facade;
  * @method static void activate(string|array $feature, mixed $value = true)
  * @method static void deactivate(string|array $feature)
  * @method static void forget(string|array $features)
+ * @method static void prune()
  *
  * @see \Laravel\Pennant\FeatureManager
  */

--- a/src/PennantServiceProvider.php
+++ b/src/PennantServiceProvider.php
@@ -32,6 +32,7 @@ class PennantServiceProvider extends ServiceProvider
             $this->commands([
                 \Laravel\Pennant\Commands\FeatureMakeCommand::class,
                 \Laravel\Pennant\Commands\PurgeCommand::class,
+                \Laravel\Pennant\Commands\PruneCommand::class,
             ]);
         }
 

--- a/tests/Feature/ArrayDriverTest.php
+++ b/tests/Feature/ArrayDriverTest.php
@@ -1144,6 +1144,19 @@ class ArrayDriverTest extends TestCase
         $this->assertEquals(4, Feature::for($user1)->value('myflag'));
         $this->assertEquals(4, Feature::for($user2)->value('myflag'));
     }
+
+    public function test_it_can_prune_undefined_features()
+    {
+        Feature::define('foo', fn () => true);
+
+        Feature::getDriver()->set('foo', 'tim', true);
+        Feature::getDriver()->set('bar', 'tim', true);
+
+        Feature::prune();
+
+        $this->assertFalse(Feature::for('tim')->active('bar'));
+        $this->assertTrue(Feature::for('tim')->active('foo'));
+    }
 }
 
 class MyFeature

--- a/tests/Feature/DatabaseDriverTest.php
+++ b/tests/Feature/DatabaseDriverTest.php
@@ -1276,6 +1276,23 @@ class DatabaseDriverTest extends TestCase
         $this->expectExceptionMessage('Database connection [xxxx] not configured.');
         Feature::store('database')->active('feature-name');
     }
+
+    public function test_it_can_prune_undefined_features()
+    {
+        Feature::define('foo', fn () => true);
+
+        Feature::getDriver()->set('foo', 'tim', true);
+        Feature::getDriver()->set('bar', 'tim', true);
+
+        Feature::prune();
+
+        $this->assertDatabaseMissing('features', [
+            'name' => 'bar',
+            'scope' => 'tim',
+        ]);
+
+        $this->assertTrue(Feature::for('tim')->active('foo'));
+    }
 }
 
 class UnregisteredFeature

--- a/tests/Feature/PruneCommandTest.php
+++ b/tests/Feature/PruneCommandTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use InvalidArgumentException;
+use Laravel\Pennant\Feature;
+use Tests\TestCase;
+
+class PruneCommandTest extends TestCase
+{
+    use LazilyRefreshDatabase;
+
+    public function test_it_can_prune_flags()
+    {
+        Feature::define('foo', true);
+
+        Feature::driver('database')->set('foo', 'tim', true);
+        Feature::driver('database')->set('foo', 'taylor', true);
+        Feature::driver('database')->set('bar', 'taylor', true);
+
+        $this->assertSame(3, DB::table('features')->count());
+
+        $this->artisan('pennant:prune')->expectsOutputToContain('Features successfully pruned from storage.');
+
+        $this->assertSame(2, DB::table('features')->count());
+    }
+
+    public function test_it_can_specify_a_driver()
+    {
+        config(['pennant.stores.custom' => ['driver' => 'custom']]);
+
+        Feature::extend('custom', fn () => new class
+        {
+            public function prune()
+            {
+                //
+            }
+        });
+
+        Feature::store('database')->define('foo', true);
+
+        Feature::driver('database')->set('foo', 'tim', true);
+        Feature::driver('database')->set('foo', 'taylor', true);
+        Feature::driver('database')->set('bar', 'taylor', true);
+
+        $this->assertSame(3, DB::table('features')->count());
+
+        $this->artisan('pennant:prune --store=custom');
+
+        $this->assertSame(3, DB::table('features')->count());
+
+        $this->artisan('pennant:prune --store=database');
+
+        $this->assertSame(2, DB::table('features')->count());
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Pennant store [foo] is not defined.');
+        $this->artisan('pennant:prune --store=foo');
+    }
+}


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

### Overview

This PR adds the ability to remove old unused features from your data store. When a feature flag definition has been removed, rather than having to manually `purge` the now undefined feature we can instead run an automated `prune`.

The logic in this PR is to look at the list of 'defined' features and remove any other features.

This will allow us to add the new `php artisan pennant:prune` command to our deployments and it will automatically clean up feature flags from the database that we no longer have defined.

### Benefits

Having this directly in Pennant saves us (and others) from implementing similar functionality in their own applications.

The changes are self-contained so shouldn't affect any existing functionality.