### PR TITLE
[1.x] Allow excluding features from purge command

### DIFF
--- a/src/Commands/PurgeCommand.php
+++ b/src/Commands/PurgeCommand.php
@@ -14,7 +14,7 @@ class PurgeCommand extends Command
      */
     protected $signature = 'pennant:purge
                             {features?* : The features to purge}
-                            {--except=* : Feature names to be excluded from purging}
+                            {--except=* : The features that should be excluded from purging}
                             {--except-registered : Purge all features except those registered}
                             {--store= : The store to purge the features from}';
 

--- a/src/Commands/PurgeCommand.php
+++ b/src/Commands/PurgeCommand.php
@@ -14,6 +14,8 @@ class PurgeCommand extends Command
      */
     protected $signature = 'pennant:purge
                             {features?* : The features to purge}
+                            {--except=* : Feature names to be excluded from purging}
+                            {--except-registered : Purge all features except those registered}
                             {--store= : The store to purge the features from}';
 
     /**
@@ -37,9 +39,27 @@ class PurgeCommand extends Command
      */
     public function handle(FeatureManager $manager)
     {
-        $manager->store($this->option('store'))->purge($this->argument('features') ?: null);
+        $store = $manager->store($this->option('store'));
 
-        with($this->argument('features') ?: ['All features'], function ($names) {
+        $features = $this->argument('features') ?: null;
+
+        $except = collect($this->option('except'))
+            ->when($this->option('except-registered'), fn ($except) => $except->merge($store->defined()))
+            ->unique()
+            ->all();
+
+        if ($except) {
+            $features = collect($features ?: $store->stored())
+                ->flip()
+                ->forget($except)
+                ->flip()
+                ->values()
+                ->all();
+        }
+
+        $store->purge($features);
+
+        with($features ?: ['All features'], function ($names) {
             $this->components->info(implode(', ', $names).' successfully purged from storage.');
         });
 

--- a/src/Contracts/CanListStoredFeatures.php
+++ b/src/Contracts/CanListStoredFeatures.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Laravel\Pennant\Contracts;
+
+interface CanListStoredFeatures
+{
+    /**
+     * Retrieve the names of all stored features.
+     *
+     * @return array<string>
+     */
+    public function stored(): array;
+}

--- a/src/Drivers/ArrayDriver.php
+++ b/src/Drivers/ArrayDriver.php
@@ -10,7 +10,7 @@ use Laravel\Pennant\Events\UnknownFeatureResolved;
 use Laravel\Pennant\Feature;
 use stdClass;
 
-class ArrayDriver implements Driver, CanListStoredFeatures
+class ArrayDriver implements CanListStoredFeatures, Driver
 {
     /**
      * The event dispatcher.

--- a/src/Drivers/ArrayDriver.php
+++ b/src/Drivers/ArrayDriver.php
@@ -4,12 +4,13 @@ namespace Laravel\Pennant\Drivers;
 
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Support\Collection;
+use Laravel\Pennant\Contracts\CanListStoredFeatures;
 use Laravel\Pennant\Contracts\Driver;
 use Laravel\Pennant\Events\UnknownFeatureResolved;
 use Laravel\Pennant\Feature;
 use stdClass;
 
-class ArrayDriver implements Driver
+class ArrayDriver implements Driver, CanListStoredFeatures
 {
     /**
      * The event dispatcher.
@@ -72,6 +73,16 @@ class ArrayDriver implements Driver
     public function defined(): array
     {
         return array_keys($this->featureStateResolvers);
+    }
+
+    /**
+     * Retrieve the names of all stored features.
+     *
+     * @return array<string>
+     */
+    public function stored(): array
+    {
+        return array_keys($this->resolvedFeatureStates);
     }
 
     /**

--- a/src/Drivers/DatabaseDriver.php
+++ b/src/Drivers/DatabaseDriver.php
@@ -8,12 +8,13 @@ use Illuminate\Database\Connection;
 use Illuminate\Database\DatabaseManager;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
+use Laravel\Pennant\Contracts\CanListStoredFeatures;
 use Laravel\Pennant\Contracts\Driver;
 use Laravel\Pennant\Events\UnknownFeatureResolved;
 use Laravel\Pennant\Feature;
 use stdClass;
 
-class DatabaseDriver implements Driver
+class DatabaseDriver implements Driver, CanListStoredFeatures
 {
     /**
      * The database connection.
@@ -86,13 +87,28 @@ class DatabaseDriver implements Driver
     }
 
     /**
-     * Define the names of all defined features.
+     * Retrieve the names of all defined features.
      *
      * @return array<string>
      */
     public function defined(): array
     {
         return array_keys($this->featureStateResolvers);
+    }
+
+    /**
+     * Retrieve the names of all stored features.
+     *
+     * @return array<string>
+     */
+    public function stored(): array
+    {
+        return $this->newQuery()
+            ->select('name')
+            ->distinct()
+            ->get()
+            ->pluck('name')
+            ->all();
     }
 
     /**

--- a/src/Drivers/DatabaseDriver.php
+++ b/src/Drivers/DatabaseDriver.php
@@ -14,7 +14,7 @@ use Laravel\Pennant\Events\UnknownFeatureResolved;
 use Laravel\Pennant\Feature;
 use stdClass;
 
-class DatabaseDriver implements Driver, CanListStoredFeatures
+class DatabaseDriver implements CanListStoredFeatures, Driver
 {
     /**
      * The database connection.

--- a/src/Drivers/Decorator.php
+++ b/src/Drivers/Decorator.php
@@ -31,7 +31,7 @@ use Symfony\Component\Finder\Finder;
 /**
  * @mixin \Laravel\Pennant\PendingScopedFeatureInteraction
  */
-class Decorator implements Driver, CanListStoredFeatures
+class Decorator implements CanListStoredFeatures, Driver
 {
     use Macroable {
         __call as macroCall;

--- a/src/Drivers/Decorator.php
+++ b/src/Drivers/Decorator.php
@@ -10,7 +10,7 @@ use Illuminate\Support\Lottery;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Macroable;
 use Laravel\Pennant\Contracts\CanListStoredFeatures;
-use Laravel\Pennant\Contracts\Driver as DriverContract;
+use Laravel\Pennant\Contracts\Driver;
 use Laravel\Pennant\Contracts\FeatureScopeable;
 use Laravel\Pennant\Events\AllFeaturesPurged;
 use Laravel\Pennant\Events\DynamicallyRegisteringFeatureClass;
@@ -31,7 +31,7 @@ use Symfony\Component\Finder\Finder;
 /**
  * @mixin \Laravel\Pennant\PendingScopedFeatureInteraction
  */
-class Decorator implements DriverContract, CanListStoredFeatures
+class Decorator implements Driver, CanListStoredFeatures
 {
     use Macroable {
         __call as macroCall;

--- a/tests/Feature/ArrayDriverTest.php
+++ b/tests/Feature/ArrayDriverTest.php
@@ -1144,6 +1144,16 @@ class ArrayDriverTest extends TestCase
         $this->assertEquals(4, Feature::for($user1)->value('myflag'));
         $this->assertEquals(4, Feature::for($user2)->value('myflag'));
     }
+
+    public function test_it_can_list_stored_features()
+    {
+        Feature::define('foo', fn () => true);
+        Feature::define('bar', fn () => true);
+
+        Feature::for('Tim')->active('bar');
+
+        $this->assertSame(Feature::stored(), ['bar']);
+    }
 }
 
 class MyFeature

--- a/tests/Feature/DatabaseDriverTest.php
+++ b/tests/Feature/DatabaseDriverTest.php
@@ -1276,6 +1276,23 @@ class DatabaseDriverTest extends TestCase
         $this->expectExceptionMessage('Database connection [xxxx] not configured.');
         Feature::store('database')->active('feature-name');
     }
+
+    public function test_it_can_list_stored_features()
+    {
+        Feature::define('foo', fn () => true);
+        Feature::define('bar', fn () => true);
+
+        Feature::for('tim')->active('bar');
+        DB::table('features')->insert([
+            'name' => 'baz',
+            'scope' => 'Tim',
+            'value' => true,
+            'created_at' => now()->toDateTimeString(),
+            'updated_at' => now()->toDateTimeString(),
+        ]);
+
+        $this->assertSame(Feature::stored(), ['bar', 'baz']);
+    }
 }
 
 class UnregisteredFeature

--- a/tests/Feature/PurgeCommandTest.php
+++ b/tests/Feature/PurgeCommandTest.php
@@ -157,7 +157,7 @@ class PurgeCommandTest extends TestCase
             'updated_at' => now()->toDateTimeString(),
         ]);
 
-        $this->artisan('pennant:purge foo bar --except=bar')->expectsOutputToContain('foo successfully purged from storage.');;
+        $this->artisan('pennant:purge foo bar --except=bar')->expectsOutputToContain('foo successfully purged from storage.');
 
         $this->assertSame(['bar', 'baz'], DB::table('features')->pluck('name')->all());
     }
@@ -187,7 +187,7 @@ class PurgeCommandTest extends TestCase
             'updated_at' => now()->toDateTimeString(),
         ]);
 
-        $this->artisan('pennant:purge --except-registered')->expectsOutputToContain('bar, baz successfully purged from storage.');;
+        $this->artisan('pennant:purge --except-registered')->expectsOutputToContain('bar, baz successfully purged from storage.');
 
         $this->assertSame(['foo'], DB::table('features')->pluck('name')->all());
     }

--- a/tests/Feature/PurgeCommandTest.php
+++ b/tests/Feature/PurgeCommandTest.php
@@ -103,4 +103,92 @@ class PurgeCommandTest extends TestCase
         $this->expectExceptionMessage('Pennant store [foo] is not defined.');
         $this->artisan('pennant:purge --store=foo');
     }
+
+    public function test_it_can_exclude_features_to_purge_from_storage()
+    {
+        Feature::define('foo', true);
+        Feature::define('bar', false);
+
+        Feature::for('tim')->active('foo');
+        Feature::for('taylor')->active('foo');
+
+        Feature::for('taylor')->active('bar');
+
+        DB::table('features')->insert([
+            'name' => 'baz',
+            'scope' => 'Tim',
+            'value' => true,
+            'created_at' => now()->toDateTimeString(),
+            'updated_at' => now()->toDateTimeString(),
+        ]);
+
+        $this->assertCount(3, DB::table('features')->get()->unique('name'));
+
+        $this->artisan('pennant:purge --except=foo')->expectsOutputToContain('bar, baz successfully purged from storage.');
+
+        $this->assertCount(1, DB::table('features')->get()->unique('name'));
+
+        $this->artisan('pennant:purge foo')->expectsOutputToContain('foo successfully purged from storage.');
+
+        $this->assertSame(0, DB::table('features')->count());
+    }
+
+    public function test_it_can_combine_except_and_features_as_arguments()
+    {
+        DB::table('features')->insert([
+            'name' => 'foo',
+            'scope' => 'Tim',
+            'value' => true,
+            'created_at' => now()->toDateTimeString(),
+            'updated_at' => now()->toDateTimeString(),
+        ]);
+        DB::table('features')->insert([
+            'name' => 'bar',
+            'scope' => 'Tim',
+            'value' => true,
+            'created_at' => now()->toDateTimeString(),
+            'updated_at' => now()->toDateTimeString(),
+        ]);
+        DB::table('features')->insert([
+            'name' => 'baz',
+            'scope' => 'Tim',
+            'value' => true,
+            'created_at' => now()->toDateTimeString(),
+            'updated_at' => now()->toDateTimeString(),
+        ]);
+
+        $this->artisan('pennant:purge foo bar --except=bar')->expectsOutputToContain('foo successfully purged from storage.');;
+
+        $this->assertSame(['bar', 'baz'], DB::table('features')->pluck('name')->all());
+    }
+
+    public function test_it_can_purge_features_except_those_registered()
+    {
+        Feature::define('foo', fn () => true);
+        DB::table('features')->insert([
+            'name' => 'foo',
+            'scope' => 'Tim',
+            'value' => true,
+            'created_at' => now()->toDateTimeString(),
+            'updated_at' => now()->toDateTimeString(),
+        ]);
+        DB::table('features')->insert([
+            'name' => 'bar',
+            'scope' => 'Tim',
+            'value' => true,
+            'created_at' => now()->toDateTimeString(),
+            'updated_at' => now()->toDateTimeString(),
+        ]);
+        DB::table('features')->insert([
+            'name' => 'baz',
+            'scope' => 'Tim',
+            'value' => true,
+            'created_at' => now()->toDateTimeString(),
+            'updated_at' => now()->toDateTimeString(),
+        ]);
+
+        $this->artisan('pennant:purge --except-registered')->expectsOutputToContain('bar, baz successfully purged from storage.');;
+
+        $this->assertSame(['foo'], DB::table('features')->pluck('name')->all());
+    }
 }


### PR DESCRIPTION
Re-implementation of https://github.com/laravel/pennant/pull/87

Documentation: https://github.com/laravel/docs/pull/9448

Allows for excluding features from the purge command. This command now has the following API:

```sh
# Purge everything from storage (already exists)

php artisan pennant:purge

# Purge specific features from storage (already exists)

php artisan pennant:purge foo bar

# Purge all features from storage except those specified (new ✨)

php artisan pennant:purge --except=foo --except=bar

# Purge all features from storage except those registered (new ✨)

php artisan pennant:purge --except-registered
```

## `--except-registered`?

You could run this on deploy to clear out feature flags you no longer use.

> [!WARNING]
> Pennant allows you to _dynamically_ register features, i.e., they don't have to be defined in a service provider. If you use this flag it may clear features you still use in your application if you are using dynamic registration.

## Use in combination

The command handles using all of these in combination, e.g., it will be able to handle the following...

```sh
php artisan pennant:purge foo bar --except=bar --except-registered
```

The _excepts_ will always take precedence and ensure that any features found in that list are not purged, even if they are explicitly passed to the command like we did with `foo` and `bar`.

## 3rd party drivers

Drivers should implement the `CanListStoredFeatures` interface if they wish to support these new features. This contract adds a single new method, `stored`, which returns a unique list of stored feature names - similar to the `defined` interface method which returns a unique list of all the defined feature names.