### PR TITLE
Make timestamp column names easy to change

### DIFF
--- a/src/Drivers/DatabaseDriver.php
+++ b/src/Drivers/DatabaseDriver.php
@@ -58,6 +58,20 @@ class DatabaseDriver implements Driver
     protected $unknownFeatureValue;
 
     /**
+     * The name of the "created at" column.
+     *
+     * @var string|null
+     */
+    const CREATED_AT = 'created_at';
+
+    /**
+     * The name of the "updated at" column.
+     *
+     * @var string|null
+     */
+    const UPDATED_AT = 'updated_at';
+
+    /**
      * Create a new driver instance.
      *
      * @param  array<string, (callable(mixed $scope): mixed)>  $featureStateResolvers
@@ -142,8 +156,8 @@ class DatabaseDriver implements Driver
 
             $this->newQuery()->insert($inserts->map(fn ($insert) => [
                 ...$insert,
-                'created_at' => $now,
-                'updated_at' => $now,
+                static::CREATED_AT => $now,
+                static::UPDATED_AT => $now,
             ])->all());
         }
 
@@ -232,7 +246,7 @@ class DatabaseDriver implements Driver
             ->where('name', $feature)
             ->update([
                 'value' => json_encode($value, flags: JSON_THROW_ON_ERROR),
-                'updated_at' => Carbon::now(),
+                static::UPDATED_AT => Carbon::now(),
             ]);
     }
 
@@ -260,7 +274,7 @@ class DatabaseDriver implements Driver
             ->where('scope', $serialized)
             ->update([
                 'value' => json_encode($value, flags: JSON_THROW_ON_ERROR),
-                'updated_at' => Carbon::now(),
+                static::UPDATED_AT => Carbon::now(),
             ]);
 
         return true;
@@ -280,8 +294,8 @@ class DatabaseDriver implements Driver
             'name' => $feature,
             'scope' => Feature::serializeScope($scope),
             'value' => json_encode($value, flags: JSON_THROW_ON_ERROR),
-            'created_at' => $now = Carbon::now(),
-            'updated_at' => $now,
+            static::CREATED_AT => $now = Carbon::now(),
+            static::UPDATED_AT => $now,
         ]);
     }
 


### PR DESCRIPTION
Our database schema uses camelCase for column names instead of snake_case.

Eloquent models allow you to [change the column names for the timestamp columns](https://github.com/laravel/framework/blob/10.x/src/Illuminate/Database/Eloquent/Model.php#L218) and it would be really nice if we could do the same in Pennant.

It would allow us to extend the DatabaseDriver and just change the two constants instead of overriding the `getAll()` `insert()` and `update()` functions.

```php
<?php

namespace App\Extensions;

use Laravel\Pennant\Drivers\DatabaseDriver;

class CustomDatabaseDriver extends DatabaseDriver
{
    const CREATED_AT = 'dateCreated';
    const UPDATED_AT = 'dateModified';
}

```