### PR TITLE
Ensure strings

### DIFF
--- a/src/Drivers/DatabaseDriver.php
+++ b/src/Drivers/DatabaseDriver.php
@@ -61,14 +61,14 @@ class DatabaseDriver implements CanListStoredFeatures, Driver
     /**
      * The name of the "created at" column.
      *
-     * @var string|null
+     * @var string
      */
     const CREATED_AT = 'created_at';
 
     /**
      * The name of the "updated at" column.
      *
-     * @var string|null
+     * @var string
      */
     const UPDATED_AT = 'updated_at';
 


### PR DESCRIPTION
The driver will not function if these were `null`. Must be a string.