### PR TITLE
[1.x] Allows easy toggling of Feature's value

### DIFF
--- a/src/PendingScopedFeatureInteraction.php
+++ b/src/PendingScopedFeatureInteraction.php
@@ -257,13 +257,18 @@ class PendingScopedFeatureInteraction
      * Toggle the feature's value.
      *
      * @param  string|array<string>  $feature
+     * @param  mixed  $value
      * @return void
      */
-    public function toggle($feature)
+    public function toggle($feature, $value = null)
     {
         Collection::wrap($feature)
             ->crossJoin($this->scope())
-            ->each(fn ($bits) => $this->driver->set($bits[0], $bits[1], ! $this->driver->get($bits[0], $bits[1])));
+            ->each(fn ($bits) => $this->driver->set($bits[0], $bits[1], match (true) {
+                $value !== null && $this->driver->get($bits[0], $bits[1]) => false,
+                $value !== null => $value,
+                default => ! $this->driver->get($bits[0], $bits[1]),
+            }));
     }
 
     /**

--- a/src/PendingScopedFeatureInteraction.php
+++ b/src/PendingScopedFeatureInteraction.php
@@ -265,9 +265,9 @@ class PendingScopedFeatureInteraction
         Collection::wrap($feature)
             ->crossJoin($this->scope())
             ->each(fn ($bits) => $this->driver->set($bits[0], $bits[1], match (true) {
-                $value !== null && $this->driver->get($bits[0], $bits[1]) => false,
-                $value !== null => $value,
-                default => ! $this->driver->get($bits[0], $bits[1]),
+                $value === null => ! $this->driver->get($bits[0], $bits[1]),
+                ! $this->driver->get($bits[0], $bits[1]) => $value,
+                default => false,
             }));
     }
 

--- a/src/PendingScopedFeatureInteraction.php
+++ b/src/PendingScopedFeatureInteraction.php
@@ -254,6 +254,19 @@ class PendingScopedFeatureInteraction
     }
 
     /**
+     * Toggle the feature.
+     *
+     * @param  string|array<string>  $feature
+     * @return void
+     */
+    public function toggle($feature)
+    {
+        Collection::wrap($feature)
+            ->crossJoin($this->scope())
+            ->each(fn ($bits) => $this->driver->set($bits[0], $bits[1], ! $this->driver->get($bits[0], $bits[1])));
+    }
+
+    /**
      * Forget the flags value.
      *
      * @param  string|array<string>  $features

--- a/src/PendingScopedFeatureInteraction.php
+++ b/src/PendingScopedFeatureInteraction.php
@@ -265,9 +265,8 @@ class PendingScopedFeatureInteraction
         Collection::wrap($feature)
             ->crossJoin($this->scope())
             ->each(fn ($bits) => $this->driver->set($bits[0], $bits[1], match (true) {
-                $value === null && is_bool($this->driver->get($bits[0], $bits[1])) => ! $this->driver->get($bits[0], $bits[1]),
-                $value === null => false,
-                is_bool($this->driver->get($bits[0], $bits[1])) && $this->driver->get($bits[0], $bits[1]) === false => $value,
+                null === $value => false === $this->driver->get($bits[0], $bits[1]) ? true : false,
+                false === $this->driver->get($bits[0], $bits[1]) => $value,
                 default => false,
             }));
     }

--- a/src/PendingScopedFeatureInteraction.php
+++ b/src/PendingScopedFeatureInteraction.php
@@ -254,7 +254,7 @@ class PendingScopedFeatureInteraction
     }
 
     /**
-     * Toggle the feature.
+     * Toggle the feature's value.
      *
      * @param  string|array<string>  $feature
      * @return void

--- a/src/PendingScopedFeatureInteraction.php
+++ b/src/PendingScopedFeatureInteraction.php
@@ -265,8 +265,9 @@ class PendingScopedFeatureInteraction
         Collection::wrap($feature)
             ->crossJoin($this->scope())
             ->each(fn ($bits) => $this->driver->set($bits[0], $bits[1], match (true) {
-                $value === null => ! $this->driver->get($bits[0], $bits[1]),
-                ! $this->driver->get($bits[0], $bits[1]) => $value,
+                $value === null && is_bool($this->driver->get($bits[0], $bits[1])) => ! $this->driver->get($bits[0], $bits[1]),
+                $value === null => false,
+                is_bool($this->driver->get($bits[0], $bits[1])) && $this->driver->get($bits[0], $bits[1]) === false => $value,
                 default => false,
             }));
     }

--- a/tests/Feature/DatabaseDriverTest.php
+++ b/tests/Feature/DatabaseDriverTest.php
@@ -1323,6 +1323,23 @@ class DatabaseDriverTest extends TestCase
         Feature::for('scope')->toggle('feature', 'value');
         $this->assertSame('value', Feature::for('scope')->value('feature'));
     }
+
+    public function test_it_will_toggle_non_booleans_correctly()
+    {
+        // Will treat '0' as rich value
+        Feature::for('scope')->toggle('feature', '0');
+        $this->assertSame('0', Feature::for('scope')->value('feature'));
+        
+        Feature::for('scope')->toggle('feature');
+        $this->assertFalse(Feature::for('scope')->value('feature'));
+
+        // Will treat 0 as rich value
+        Feature::for('scope')->toggle('feature', 0);
+        $this->assertSame(0, Feature::for('scope')->value('feature'));
+
+        Feature::for('scope')->toggle('feature');
+        $this->assertFalse(Feature::for('scope')->value('feature'));
+    }
 }
 
 class UnregisteredFeature

--- a/tests/Feature/DatabaseDriverTest.php
+++ b/tests/Feature/DatabaseDriverTest.php
@@ -1293,6 +1293,36 @@ class DatabaseDriverTest extends TestCase
 
         $this->assertSame(Feature::stored(), ['bar', 'baz']);
     }
+
+    public function test_it_can_toggle_features()
+    {
+        // Can toggle unresolved feature to on.
+        Feature::for('scope')->toggle('feature');
+        $this->assertTrue(Feature::for('scope')->value('feature'));
+
+        // Can toggle active feature off.
+        Feature::for('scope')->toggle('feature');
+        $this->assertFalse(Feature::for('scope')->value('feature'));
+
+        // Can toggle inactive feature on.
+        Feature::for('scope')->toggle('feature');
+        $this->assertTrue(Feature::for('scope')->value('feature'));
+    }
+
+    public function test_it_can_toggle_feature_with_value()
+    {
+        // Can toggle unresolved feature to on.
+        Feature::for('scope')->toggle('feature', 'value');
+        $this->assertSame('value', Feature::for('scope')->value('feature'));
+
+        // Can toggle active feature off.
+        Feature::for('scope')->toggle('feature', 'value');
+        $this->assertFalse(Feature::for('scope')->value('feature'));
+
+        // Can toggle inactive feature on.
+        Feature::for('scope')->toggle('feature', 'value');
+        $this->assertSame('value', Feature::for('scope')->value('feature'));
+    }
 }
 
 class UnregisteredFeature


### PR DESCRIPTION
Hey all

This Pr adds a helper for toggling features

Adds the following method to `PendingScopedFeatureInteraction.php`

```php
    /**
     * Toggle the feature's value.
     *
     * @param  string|array<string>  $feature
     * @param  mixed  $value
     * @return void
     */
    public function toggle($feature, $value = null)
    {
        Collection::wrap($feature)
            ->crossJoin($this->scope())
            ->each(fn ($bits) => $this->driver->set($bits[0], $bits[1], match (true) {
                null === $value => false === $this->driver->get($bits[0], $bits[1]) ? true : false,
                false === $this->driver->get($bits[0], $bits[1]) => $value,
                default => false,
            }));
    }
```

shortens this:

```php
Feature::for(auth()->user())->active('new-design')  
    ? Feature::for(auth()->user())->deactivate('new-design')
    : Feature::for(auth()->user())->activate('new-design');
```

to this:

```php
Feature::for(auth()->user())->toggle('new-design');
```

EDIT:

Also supports passing a value, in order to toggle inactive and unresolved feature(s) to active with a rich value.

```php
Feature::for('scope')->toggle('danger-button', 'bg-red-200');
```
