### PR TITLE
[1.x] Safely return early if there is nothing to discover()

### DIFF
--- a/src/Drivers/Decorator.php
+++ b/src/Drivers/Decorator.php
@@ -99,6 +99,10 @@ class Decorator implements CanListStoredFeatures, Driver
      */
     public function discover($namespace = 'App\\Features', $path = null)
     {
+        if (!$path && !is_dir(base_path('app/Features'))) {
+            return;
+        }
+    
         $namespace = Str::finish($namespace, '\\');
 
         Collection::make((new Finder)


### PR DESCRIPTION
Otherwise `Feature::discover()` will throw `Symfony\ Component\Finder\Exception\ DirectoryNotFoundException` if no class based features have been added yet, or if all features have been removed.

```diff
    public function discover($namespace = 'App\\Features', $path = null)
    {

+        if (!$path && !is_dir(base_path('app/Features'))) {
+           return;
+        }
```
Prevents running into apps with a `app/Features/.gitkeep`. ( I actually caught myself doing this rather than checking for the directory before running `Feature::discover()` in a service provider)

Note:
Sometimes you need to run `Feature::discover()`  not know whether there will be any, especially if more than one developer is working on the app and whatever you are doing depends on a feature being defined (but you may not be the one to define or implement it).
