### PR TITLE
[1.x] Uses conventional "make" command naming

### DIFF
--- a/src/Commands/FeatureMakeCommand.php
+++ b/src/Commands/FeatureMakeCommand.php
@@ -6,7 +6,7 @@ use Illuminate\Console\GeneratorCommand;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputOption;
 
-#[AsCommand(name: 'pennant:feature')]
+#[AsCommand(name: 'make:feature')]
 class FeatureMakeCommand extends GeneratorCommand
 {
     /**
@@ -14,7 +14,7 @@ class FeatureMakeCommand extends GeneratorCommand
      *
      * @var string
      */
-    protected $name = 'pennant:feature';
+    protected $name = 'make:feature';
 
     /**
      * The console command description.
@@ -22,6 +22,13 @@ class FeatureMakeCommand extends GeneratorCommand
      * @var string
      */
     protected $description = 'Create a new feature class';
+
+    /**
+     * The console command name aliases.
+     *
+     * @var array<int, string>
+     */
+    protected $aliases = ['pennant:feature'];
 
     /**
      * The type of class being generated.


### PR DESCRIPTION
To make a feature we currently use `php artisan pennant:feature`. This PR renames the command to: `php artisan make:feature`

This is the current state of the ecosystems' make-style commands:

`make:folio`
`pennant:feature`
`dusk:make`
`dusk:page`
`dusk:component`

After the change:

`make:folio`
`make:feature`
`dusk:make`
`dusk:page`
`dusk:component`

The command has been aliased so `artisan pennant:feature` will continue to work.

Docs: https://github.com/laravel/docs/pull/9508