### PR TITLE
[1.x] Extract insert all

### DIFF
--- a/src/Drivers/DatabaseDriver.php
+++ b/src/Drivers/DatabaseDriver.php
@@ -336,7 +336,7 @@ class DatabaseDriver implements CanListStoredFeatures, Driver
     }
 
     /**
-     * Insert the value for the given feature and scope into storage.
+     * Insert the given feature values into storage.
      *
      * @param  array<int, array{name: string, scope: mixed, value: mixed}>  $inserts
      * @return bool

--- a/src/Drivers/DatabaseDriver.php
+++ b/src/Drivers/DatabaseDriver.php
@@ -168,8 +168,8 @@ class DatabaseDriver implements CanListStoredFeatures, Driver
 
                 $inserts[] = [
                     'name' => $feature,
-                    'scope' => Feature::serializeScope($scope),
-                    'value' => json_encode($value, flags: JSON_THROW_ON_ERROR),
+                    'scope' => $scope,
+                    'value' => $value,
                 ];
 
                 return $value;
@@ -177,14 +177,8 @@ class DatabaseDriver implements CanListStoredFeatures, Driver
         })->all())->all();
 
         if ($inserts->isNotEmpty()) {
-            $now = Carbon::now();
-
             try {
-                $this->newQuery()->insert($inserts->map(fn ($insert) => [
-                    ...$insert,
-                    static::CREATED_AT => $now,
-                    static::UPDATED_AT => $now,
-                ])->all());
+                $this->insertMany($inserts->all());
             } catch (UniqueConstraintViolationException $e) {
                 if ($this->retryDepth === 2) {
                     throw new RuntimeException('Unable to insert feature values into the database.', previous: $e);
@@ -339,6 +333,25 @@ class DatabaseDriver implements CanListStoredFeatures, Driver
             static::CREATED_AT => $now = Carbon::now(),
             static::UPDATED_AT => $now,
         ]);
+    }
+
+    /**
+     * Insert the value for the given feature and scope into storage.
+     *
+     * @param  array<int, array{name: string, scope: mixed, value: mixed}>  $inserts
+     * @return bool
+     */
+    protected function insertMany($inserts)
+    {
+        $now = Carbon::now();
+
+        return $this->newQuery()->insert(array_map(fn ($insert) => [
+            'name' => $insert['name'],
+            'scope' => Feature::serializeScope($insert['scope']),
+            'value' => json_encode($insert['value'], flags: JSON_THROW_ON_ERROR),
+            static::CREATED_AT => $now,
+            static::UPDATED_AT => $now,
+        ], $inserts));
     }
 
     /**

--- a/src/Drivers/DatabaseDriver.php
+++ b/src/Drivers/DatabaseDriver.php
@@ -216,7 +216,7 @@ class DatabaseDriver implements CanListStoredFeatures, Driver
                 $this->insert($feature, $scope, $value);
             } catch (UniqueConstraintViolationException $e) {
                 if ($this->retryDepth === 1) {
-                    throw new RuntimeException('Unable to insert feature value from the database.', previous: $e);
+                    throw new RuntimeException('Unable to insert feature value into the database.', previous: $e);
                 }
 
                 $this->retryDepth++;

--- a/src/Drivers/DatabaseDriver.php
+++ b/src/Drivers/DatabaseDriver.php
@@ -326,13 +326,11 @@ class DatabaseDriver implements CanListStoredFeatures, Driver
      */
     protected function insert($feature, $scope, $value)
     {
-        return $this->newQuery()->insert([
+        return $this->insertMany([[
             'name' => $feature,
-            'scope' => Feature::serializeScope($scope),
-            'value' => json_encode($value, flags: JSON_THROW_ON_ERROR),
-            static::CREATED_AT => $now = Carbon::now(),
-            static::UPDATED_AT => $now,
-        ]);
+            'scope' => $scope,
+            'value' => $value,
+        ]]);
     }
 
     /**

--- a/tests/Feature/DatabaseDriverTest.php
+++ b/tests/Feature/DatabaseDriverTest.php
@@ -2,12 +2,16 @@
 
 namespace Tests\Feature;
 
+use Exception;
 use Illuminate\Database\Eloquent\Relations\Relation;
+use Illuminate\Database\Events\QueryExecuted;
+use Illuminate\Database\UniqueConstraintViolationException;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Str;
 use InvalidArgumentException;
 use Laravel\Pennant\Contracts\FeatureScopeable;
 use Laravel\Pennant\Events\AllFeaturesPurged;
@@ -19,6 +23,7 @@ use Laravel\Pennant\Events\FeatureUpdated;
 use Laravel\Pennant\Events\FeatureUpdatedForAllScopes;
 use Laravel\Pennant\Events\UnknownFeatureResolved;
 use Laravel\Pennant\Feature;
+use RuntimeException;
 use Tests\TestCase;
 use Workbench\App\Models\User;
 use Workbench\Database\Factories\UserFactory;
@@ -1292,6 +1297,91 @@ class DatabaseDriverTest extends TestCase
         ]);
 
         $this->assertSame(Feature::stored(), ['bar', 'baz']);
+    }
+
+    public function test_it_retries_3_times_and_then_fails()
+    {
+        Feature::define('foo', fn () => true);
+        Feature::define('bar', fn () => true);
+        $insertAttempts = 0;
+        DB::listen(function (QueryExecuted $event) use (&$insertAttempts) {
+            if (Str::startsWith($event->sql, 'insert into "features"')) {
+                $insertAttempts++;
+                DB::table('features')->delete();
+                throw new UniqueConstraintViolationException($event->connectionName, $event->sql, $event->bindings, new RuntimeException());
+            }
+        });
+
+
+        try {
+            Feature::for('tim')->loadMissing(['foo', 'bar']);
+            $this->fail('Should have failed.');
+        } catch (Exception $e) {
+            $this->assertInstanceOf(RuntimeException::class, $e);
+            $this->assertSame('Unable to insert feature values into the database.', $e->getMessage());
+            $this->assertInstanceOf(UniqueConstraintViolationException::class, $e->getPrevious());
+        }
+
+        $this->assertSame(3, $insertAttempts);
+    }
+
+    public function test_it_only_retries_on_conflicts()
+    {
+        Feature::define('foo', fn () => true);
+        Feature::define('bar', fn () => true);
+        $insertAttempts = 0;
+        DB::listen(function (QueryExecuted $event) use (&$insertAttempts) {
+            if (Str::startsWith($event->sql, 'insert into "features"')) {
+                $insertAttempts++;
+                throw new UniqueConstraintViolationException($event->connectionName, $event->sql, $event->bindings, new RuntimeException());
+            }
+        });
+
+        Feature::for('tim')->loadMissing(['foo', 'bar']);
+
+        $this->assertSame(1, $insertAttempts);
+    }
+
+    public function test_it_retries_2_times_and_then_fails_for_individual_queries()
+    {
+        Feature::define('foo', fn () => true);
+        Feature::define('bar', fn () => true);
+        $insertAttempts = 0;
+        DB::listen(function (QueryExecuted $event) use (&$insertAttempts) {
+            if (Str::startsWith($event->sql, 'insert into "features"')) {
+                $insertAttempts++;
+                DB::table('features')->delete();
+                throw new UniqueConstraintViolationException($event->connectionName, $event->sql, $event->bindings, new RuntimeException());
+            }
+        });
+
+        try {
+            Feature::driver('database')->get('foo', 'tim');
+            $this->fail('Should have failed.');
+        } catch (Exception $e) {
+            $this->assertInstanceOf(RuntimeException::class, $e);
+            $this->assertSame('Unable to insert feature value into the database.', $e->getMessage());
+            $this->assertInstanceOf(UniqueConstraintViolationException::class, $e->getPrevious());
+        }
+
+        $this->assertSame(2, $insertAttempts);
+    }
+
+    public function test_it_only_retries_on_conflicts_for_individual_queries()
+    {
+        Feature::define('foo', fn () => true);
+        Feature::define('bar', fn () => true);
+        $insertAttempts = 0;
+        DB::listen(function (QueryExecuted $event) use (&$insertAttempts) {
+            if (Str::startsWith($event->sql, 'insert into "features"')) {
+                $insertAttempts++;
+                throw new UniqueConstraintViolationException($event->connectionName, $event->sql, $event->bindings, new RuntimeException());
+            }
+        });
+
+        Feature::driver('database')->get('foo', 'tim');
+
+        $this->assertSame(1, $insertAttempts);
     }
 }
 

--- a/tests/Feature/DatabaseDriverTest.php
+++ b/tests/Feature/DatabaseDriverTest.php
@@ -1312,7 +1312,6 @@ class DatabaseDriverTest extends TestCase
             }
         });
 
-
         try {
             Feature::for('tim')->loadMissing(['foo', 'bar']);
             $this->fail('Should have failed.');


### PR DESCRIPTION
This PR extracts an `insertMany` method to make extending the database driver easier.

Some of the community (https://github.com/laravel/pennant/pull/104#issuecomment-2135085391, https://github.com/laravel/pennant/issues/100) are extending the driver to add custom fields to the features table. With the recent changes unique constraint handling (https://github.com/laravel/pennant/pull/104) we introduced a new insert query that is not able to be intercepted in an extended class.

This PR extracts the query out to an `insertMany` method to make it easier to intercept and decorate.

Additionally it:

- Makes the existing `insert` method a proxy to the new `insertMany` method.
- Fixes a minor typo in the exception message.
- Adds some tests for the unique constraint handling.