### PR TITLE
[1.x] Ensure values returns feature name

### DIFF
--- a/src/Drivers/Decorator.php
+++ b/src/Drivers/Decorator.php
@@ -419,6 +419,17 @@ class Decorator implements CanListStoredFeatures, Driver
     }
 
     /**
+     * Retrieve the feature's name.
+     *
+     * @param  string  $feature
+     * @return string
+     */
+    public function name($feature)
+    {
+        return $this->resolveFeature($feature);
+    }
+
+    /**
      * Resolve the feature name and ensure it is defined.
      *
      * @param  string  $feature

--- a/src/PendingScopedFeatureInteraction.php
+++ b/src/PendingScopedFeatureInteraction.php
@@ -78,7 +78,7 @@ class PendingScopedFeatureInteraction
      */
     public function value($feature)
     {
-        return $this->values([$feature])[$feature];
+        return head($this->values([$feature]));
     }
 
     /**
@@ -97,7 +97,7 @@ class PendingScopedFeatureInteraction
 
         return Collection::make($features)
             ->mapWithKeys(fn ($feature) => [
-                $feature => $this->driver->get($feature, $this->scope()[0]),
+                $this->driver->name($feature) => $this->driver->get($feature, $this->scope()[0]),
             ])
             ->all();
     }


### PR DESCRIPTION
fixes https://github.com/laravel/pennant/issues/106

There is an inconsistency when retrieving a list of specific values with Pennant.

When you have a class-based feature that has a name, e.g, `$name = 'my-feature';`, the `Feature::values` function will inconstantly return the name and the feature's classname.

Given the following class...

```php
namespace App\Features;

class MyFeature
{
    public $name = 'my-feature';

    // ...
}
```

We see the inconsistency in the last call to `Feature::values`:

```php
Feature::all();

// ✅
// 
// [
//     'my-feature' => true,
// ]

Feature::values(['my-feature']);

// ✅
// 
// [
//     'my-feature' => true,
// ]

Feature::values([Myfeature::class]);

// ❌
// 
// [
//     'App\Features\MyFeature' => true,
// ]
```

Given the main usecase for the `Feature::values` function is to pass features to the front end...

```blade
<script>
const features = @js(Feature::values(['feature-1', 'feature-2']))
</script>

<div v-if="features['feature-1']>
    <!-- ... -->
</div>
```

...and the main usecase for the `$name` is to decouple the database and front end from the back end implementation, this feels like a bug that we should address.