### PR TITLE
[1.x] Use constant for updated_at column name

### DIFF
--- a/src/Drivers/DatabaseDriver.php
+++ b/src/Drivers/DatabaseDriver.php
@@ -278,7 +278,7 @@ class DatabaseDriver implements CanListStoredFeatures, Driver
             'value' => json_encode($value, flags: JSON_THROW_ON_ERROR),
             static::CREATED_AT => $now = Carbon::now(),
             static::UPDATED_AT => $now,
-        ], uniqueBy: ['name', 'scope'], update: ['value', 'updated_at']);
+        ], uniqueBy: ['name', 'scope'], update: ['value', static::CREATED_AT]);
     }
 
     /**


### PR DESCRIPTION
https://github.com/laravel/pennant/commit/2226b130946ae99c95e33bef16b2d05cf243f1fd re-introduced the 'updated_at' string instead of using the UPDATED_AT constant added here https://github.com/laravel/pennant/commit/c703915692bf3c8d9b0cf8ff2bef195809eb31f1

This PR uses the constant instead of the string.