### PR TITLE
[1.x] Fixes wrong column reference

### DIFF
--- a/src/Drivers/DatabaseDriver.php
+++ b/src/Drivers/DatabaseDriver.php
@@ -278,7 +278,7 @@ class DatabaseDriver implements CanListStoredFeatures, Driver
             'value' => json_encode($value, flags: JSON_THROW_ON_ERROR),
             static::CREATED_AT => $now = Carbon::now(),
             static::UPDATED_AT => $now,
-        ], uniqueBy: ['name', 'scope'], update: ['value', static::CREATED_AT]);
+        ], uniqueBy: ['name', 'scope'], update: ['value', static::UPDATED_AT]);
     }
 
     /**


### PR DESCRIPTION
https://github.com/laravel/pennant/pull/108 unintentionally switched the `updated_at` column with the `created_at` column when refactoring to using constants.