### PR TITLE
Add `loadAll` method

### DIFF
--- a/src/PendingScopedFeatureInteraction.php
+++ b/src/PendingScopedFeatureInteraction.php
@@ -71,6 +71,17 @@ class PendingScopedFeatureInteraction
     }
 
     /**
+     * Load all defined features into memory.
+     *
+     * @param  string|array<int, string>  $features
+     * @return array<string, array<int, mixed>>
+     */
+    public function loadAll()
+    {
+        return $this->load($this->driver->defined());
+    }
+
+    /**
      * Get the value of the flag.
      *
      * @param  string  $feature

--- a/tests/Feature/DatabaseDriverTest.php
+++ b/tests/Feature/DatabaseDriverTest.php
@@ -1547,26 +1547,26 @@ class DatabaseDriverTest extends TestCase
 
         $records = DB::table('features')->orderBy('scope')->orderBy('name')->get(['name', 'scope', 'value'])->all();
         $this->assertCount(4, $records);
-        $this->assertEquals(literal(
-            scope: 'taylor',
-            value: 'true',
-            name: 'bar',
-        ), $records[0]);
-        $this->assertEquals(literal(
-            scope: 'taylor',
-            value: 'false',
-            name: 'foo',
-        ), $records[1]);
-        $this->assertEquals(literal(
-            scope: 'tim',
-            value: 'false',
-            name: 'bar',
-        ), $records[2]);
-        $this->assertEquals(literal(
-            scope: 'tim',
-            value: 'true',
-            name: 'foo',
-        ), $records[3]);
+        $this->assertEquals((object) [
+            'scope' => 'taylor',
+            'value' => 'true',
+            'name' => 'bar',
+        ], $records[0]);
+        $this->assertEquals((object) [
+            'scope' => 'taylor',
+            'value' => 'false',
+            'name' => 'foo',
+        ], $records[1]);
+        $this->assertEquals((object) [
+            'scope' => 'tim',
+            'value' => 'false',
+            'name' => 'bar',
+        ], $records[2]);
+        $this->assertEquals((object) [
+            'scope' => 'tim',
+            'value' => 'true',
+            'name' => 'foo',
+        ], $records[3]);
     }
 }
 

--- a/tests/Feature/DatabaseDriverTest.php
+++ b/tests/Feature/DatabaseDriverTest.php
@@ -1537,6 +1537,37 @@ class DatabaseDriverTest extends TestCase
             FeatureWithoutName::class,
         ]));
     }
+
+    public function testItCanLoadAllFeaturesForScope()
+    {
+        Feature::define('bar', fn ($scope) => $scope === 'taylor');
+        Feature::define('foo', fn ($scope) => $scope === 'tim');
+
+        Feature::for(['tim', 'taylor'])->loadAll();
+
+        $records = DB::table('features')->orderBy('scope')->orderBy('name')->get(['name', 'scope', 'value'])->all();
+        $this->assertCount(4, $records);
+        $this->assertEquals(literal(
+            scope: 'taylor',
+            value: 'true',
+            name: 'bar',
+        ), $records[0]);
+        $this->assertEquals(literal(
+            scope: 'taylor',
+            value: 'false',
+            name: 'foo',
+        ), $records[1]);
+        $this->assertEquals(literal(
+            scope: 'tim',
+            value: 'false',
+            name: 'bar',
+        ), $records[2]);
+        $this->assertEquals(literal(
+            scope: 'tim',
+            value: 'true',
+            name: 'foo',
+        ), $records[3]);
+    }
 }
 
 class UnregisteredFeature


### PR DESCRIPTION
Introduces a `loadAll` method to make loading all defined features easier.

```diff
- Feature::for($user)->load(['feature-1', 'feature-2']);
+ Feature::for($user)->loadAll();
```

// or

```diff
- Feature::for($user)->load(Feature::defined());
+ Feature::for($user)->loadAll();
```

I don't feel this needs a `loadAllMissing` variant as this would likely be the first thing you do in your stack.