### PR TITLE
Fixes purge output message when nothing is purged

### DIFF
--- a/src/Commands/PurgeCommand.php
+++ b/src/Commands/PurgeCommand.php
@@ -63,7 +63,7 @@ class PurgeCommand extends Command
 
         if ($features) {
             $this->components->info(implode(', ', $features).' successfully purged from storage.');
-        } else if ($except) {
+        } elseif ($except) {
             $this->components->info('No features to purge from storage.');
         } else {
             $this->components->info('All features successfully purged from storage.');

--- a/src/Commands/PurgeCommand.php
+++ b/src/Commands/PurgeCommand.php
@@ -61,9 +61,13 @@ class PurgeCommand extends Command
 
         $store->purge($features);
 
-        with($features ?: ['All features'], function ($names) {
-            $this->components->info(implode(', ', $names).' successfully purged from storage.');
-        });
+        if ($features) {
+            $this->components->info(implode(', ', $features).' successfully purged from storage.');
+        } else if ($except) {
+            $this->components->info('No features to purge from storage.');
+        } else {
+            $this->components->info('All features successfully purged from storage.');
+        }
 
         return self::SUCCESS;
     }

--- a/tests/Feature/PurgeCommandTest.php
+++ b/tests/Feature/PurgeCommandTest.php
@@ -133,6 +133,20 @@ class PurgeCommandTest extends TestCase
         $this->assertSame(0, DB::table('features')->count());
     }
 
+    public function test_it_outputs_that_no_features_have_been_purged()
+    {
+        Feature::define('foo', true);
+
+        Feature::for('tim')->active('foo');
+        Feature::for('taylor')->active('foo');
+
+        $this->assertSame(2, DB::table('features')->where('name', 'foo')->count());
+
+        $this->artisan('pennant:purge --except=foo')->expectsOutputToContain('No features to purge from storage.');
+
+        $this->assertSame(2, DB::table('features')->where('name', 'foo')->count());
+    }
+
     public function test_it_can_combine_except_and_features_as_arguments()
     {
         DB::table('features')->insert([


### PR DESCRIPTION
When using the `--except` flags, you can sometimes see the message "All features purged from storage" when nothing has been purged.


Imagine you have a feature defined and have that feature has been resolved and stored in the database...
```php
Feature::define('feature-name', true);

Feature::active('feature-name');
```

Then when you run the command to purge everything _except_ that feature, which means nothing is going to be purged, it outputs the wrong message.

```diff
php artisan pennant:purge --except=feature-name

- All features successfully purged from storage.
+ No features to purge from storage.
```