### PR TITLE
[1.x] Adds `Feature::activeForAny()`

### DIFF
--- a/src/PendingScopedFeatureInteraction.php
+++ b/src/PendingScopedFeatureInteraction.php
@@ -152,7 +152,7 @@ class PendingScopedFeatureInteraction
     /**
      * Determine if any of the features are active.
      *
-     * @param  array<int, string>|string  $features
+     * @param  array<string>  $features
      * @return bool
      */
     public function someAreActive($features)

--- a/src/PendingScopedFeatureInteraction.php
+++ b/src/PendingScopedFeatureInteraction.php
@@ -152,7 +152,7 @@ class PendingScopedFeatureInteraction
     /**
      * Determine if any of the features are active.
      *
-     * @param  array<string>  $features
+     * @param  array<int, string>|string  $features
      * @return bool
      */
     public function someAreActive($features)
@@ -161,6 +161,21 @@ class PendingScopedFeatureInteraction
 
         return Collection::make($this->scope())
             ->every(fn ($scope) => Collection::make($features)
+                ->some(fn ($feature) => $this->driver->get($feature, $scope) !== false));
+    }
+
+    /**
+     * Determine if even one feature is active for any of the given scopes.
+     *
+     * @param array<int, string>|string $features
+     * @return bool
+     */
+    public function activeForAny($features)
+    {
+        $this->loadMissing($features);
+
+        return Collection::make($this->scope())
+            ->some(fn ($scope) => Collection::make($features)
                 ->some(fn ($feature) => $this->driver->get($feature, $scope) !== false));
     }
 

--- a/tests/Feature/DatabaseDriverTest.php
+++ b/tests/Feature/DatabaseDriverTest.php
@@ -1063,6 +1063,24 @@ class DatabaseDriverTest extends TestCase
         ], $all);
     }
 
+    public function test_it_checks_if_at_least_one_is_active()
+    {
+        // Given
+        Feature::define('foo', false);
+
+        // assert pre-condition
+        $this->assertFalse(Feature::for(['tim', 'taylor'])->activeForAny('foo'));
+
+        // And
+        Feature::for(['tim'])->activate('foo');
+
+        // When
+        $result = Feature::for(['taylor', 'tim'])->activeForAny(['foo', 'bar']);
+
+        // Then
+        $this->assertTrue($result);
+    }
+
     public function test_it_handles_multiscope_checks()
     {
         Feature::define('foo', false);

--- a/tests/Feature/DatabaseDriverTest.php
+++ b/tests/Feature/DatabaseDriverTest.php
@@ -1063,7 +1063,20 @@ class DatabaseDriverTest extends TestCase
         ], $all);
     }
 
-    public function test_it_checks_if_at_least_one_is_active()
+    public function test_it_checks_if_any_are_active_for_default_scope()
+    {
+        Feature::define('feat', false);
+        Feature::define('always-false', false);
+        $this->assertFalse(Feature::activeForAny(['feat']));
+
+        Feature::activate('feat');
+
+        $this->assertTrue(Feature::activeForAny(['feat']));
+        $this->assertTrue(Feature::activeForAny(['always-false', 'feat']));
+
+    }
+
+    public function test_it_checks_if_at_least_one_is_active_in_multiscope()
     {
         // Given
         Feature::define('foo', false);


### PR DESCRIPTION
I want to be able to check if any of a user's related models have a particular feature enabled.

```php
$schools = $user->loadMissing('schools');
$featureIsActive = Feature::for($schools)->someAreActive('enrolled-in-beta');
```

But this actually is checking that all of the schools have at least one of the features (in this case it's just one feature, `'enrolled-in-beta'`, which is gets wrapped as an array) being passed in. So if all of the user's schools don't have the feature enabled, `$featureIsActive` is false.

With the change in this PR, we can accomplish that with:

```php
$featureIsActive = Feature::for($schools)->activeForAny('enrolled-in-beta');
```

---
I would have just changed `someAreActive()` but it seems like that would be a breaking change (proven by the fact I would have to modify tests) 😢 hence the new method.