### PR TITLE
[1.x] Add ability to resolve feature instance.

### DIFF
--- a/src/Drivers/Decorator.php
+++ b/src/Drivers/Decorator.php
@@ -74,6 +74,8 @@ class Decorator implements CanListStoredFeatures, Driver
 
     /**
      * Map of feature names to their implementations.
+     *
+     * @var array<string, mixed>
      */
     protected $nameMap = [];
 

--- a/src/Drivers/Decorator.php
+++ b/src/Drivers/Decorator.php
@@ -73,6 +73,11 @@ class Decorator implements CanListStoredFeatures, Driver
     protected $cache;
 
     /**
+     * Map of feature names to their implementations.
+     */
+    protected $nameMap = [];
+
+    /**
      * Create a new driver decorator instance.
      *
      * @param  string  $name
@@ -122,6 +127,10 @@ class Decorator implements CanListStoredFeatures, Driver
                 $this->container->make($feature)->name ?? $feature,
                 new LazilyResolvedFeature($feature),
             ];
+
+            $this->nameMap[$feature] = $resolver->feature;
+        } else {
+            $this->nameMap[$feature] = $resolver;
         }
 
         $this->driver->define($feature, function ($scope) use ($feature, $resolver) {
@@ -486,6 +495,27 @@ class Decorator implements CanListStoredFeatures, Driver
     public function name($feature)
     {
         return $this->resolveFeature($feature);
+    }
+
+    /**
+     * Retrieve the feature's class.
+     *
+     * @param  string  $feature
+     * @return mixed
+     */
+    public function instance($name)
+    {
+        $feature = $this->nameMap[$name] ?? $name;
+
+        if (is_string($feature) && class_exists($feature)) {
+            return $this->container->make($feature);
+        }
+
+        if ($feature instanceof Closure || $feature instanceof Lottery) {
+            return $feature;
+        }
+
+        return fn () => $feature;
     }
 
     /**

--- a/tests/Feature/ArrayDriverTest.php
+++ b/tests/Feature/ArrayDriverTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature;
 
+use Closure;
 use Illuminate\Container\Container;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Config;
@@ -1153,6 +1154,29 @@ class ArrayDriverTest extends TestCase
         Feature::for('Tim')->active('bar');
 
         $this->assertSame(Feature::stored(), ['bar']);
+    }
+
+    public function test_it_can_resolve_feature_instance()
+    {
+        Feature::define(MyFeature::class);
+        $this->assertInstanceOf(MyFeature::class, Feature::instance('my-feature'));
+        $this->assertInstanceOf(MyFeature::class, Feature::instance(MyFeature::class));
+
+        Feature::define(MyUnnamedFeature::class);
+        $this->assertInstanceOf(MyUnnamedFeature::class, Feature::instance(MyUnnamedFeature::class));
+
+        Feature::define('closure-based-feature', $closure = fn () => true);
+        $this->assertSame($closure, Feature::instance('closure-based-feature'));
+
+        Feature::define('value-based-feature', '123');
+        $feature = Feature::instance('value-based-feature');
+        $this->assertInstanceOf(Closure::class, $feature);
+        $this->assertSame('123', $feature());
+
+        Feature::define('lottery-based-feature', Lottery::odds(1, 1)->winner(fn () => '345'));
+        $feature = Feature::instance('lottery-based-feature');
+        $this->assertInstanceOf(Lottery::class, $feature);
+        $this->assertSame('345', $feature());
     }
 }
 


### PR DESCRIPTION
This PR gives the ability to resolve the implementation of the feature.

```php
class MyFeature
{
    public $name = 'my-feature';

    // ...
}

Feature::define(MyFeature::class);

$instance = Feature::instance('my-feature');
$instance = Feature::instance(MyFeature::class);
```

The `instance` method will return either an instance of the feature class, a lottery, or a closure. The tests give a good rundown of when each of these might occur.