### PR TITLE
[1.x] Add a new `@featureany` directive

### DIFF
--- a/src/PennantServiceProvider.php
+++ b/src/PennantServiceProvider.php
@@ -43,6 +43,10 @@ class PennantServiceProvider extends ServiceProvider
 
                 return Feature::active($feature);
             });
+
+            $blade->if('featureany', function ($features) {
+                return Feature::someAreActive($features);
+            });
         });
 
         $this->listenForEvents();

--- a/tests/Feature/FeatureDirectiveTest.php
+++ b/tests/Feature/FeatureDirectiveTest.php
@@ -76,4 +76,27 @@ class FeatureDirectiveTest extends TestCase
         $output = trim(Blade::render($blade));
         $this->assertSame('foo is 888', $output);
     }
+
+    public function test_it_renders_any_active_features()
+    {
+        $blade = <<<'BLADE'
+        @featureany(['foo', 'bar'])
+            foo or bar is active
+        @else
+            foo and bar are inactive
+        @endfeatureany
+        BLADE;
+
+        $output = trim(Blade::render($blade));
+        $this->assertSame('foo and bar are inactive', $output);
+
+        Feature::activate('foo');
+        $output = trim(Blade::render($blade));
+        $this->assertSame('foo or bar is active', $output);
+
+        Feature::deactivate('foo');
+        Feature::activate('bar');
+        $output = trim(Blade::render($blade));
+        $this->assertSame('foo or bar is active', $output);
+    }
 }


### PR DESCRIPTION
Similar to the `@canany` directive that Laravel provides, this new directive allows you to check the status of multiple features at once with boolean OR behaviour with the `@featureany` directive.

```blade
@featureany(['foo', 'bar'])
    foo or bar is active
@else
    foo and bar are inactive
@endfeatureany
```

I went for the `featureany` since it is more inline with other directives that do a similar thing, but I also had the idea of adding array support to the regular `@feature` directive.

There's no value comparison support because it didn't make sense since different features will likely have different values.

Open to feedback of course!