### PR TITLE
[1.x] Add `activeOrFail` method

### DIFF
--- a/src/Exceptions/FeatureInactiveException.php
+++ b/src/Exceptions/FeatureInactiveException.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Laravel\Pennant\Exceptions;
+
+use RuntimeException;
+
+class FeatureInactiveException extends RuntimeException
+{
+    /**
+     * Create a new exception instance.
+     */
+    public function __construct(string $feature)
+    {
+        parent::__construct(sprintf('The feature [%s] is not active.', $feature));
+    }
+}

--- a/src/PendingScopedFeatureInteraction.php
+++ b/src/PendingScopedFeatureInteraction.php
@@ -3,6 +3,7 @@
 namespace Laravel\Pennant;
 
 use Illuminate\Support\Collection;
+use Laravel\Pennant\Exceptions\FeatureInactiveException;
 use RuntimeException;
 
 class PendingScopedFeatureInteraction
@@ -132,6 +133,21 @@ class PendingScopedFeatureInteraction
     public function active($feature)
     {
         return $this->allAreActive([$feature]);
+    }
+
+    /**
+     * Determine if the feature is active, or throw an exception if it is not.
+     *
+     * @param  string  $feature
+     * @return bool
+     */
+    public function activeOrFail($feature)
+    {
+        if ($this->allAreActive([$feature])) {
+            return true;
+        }
+
+        throw new FeatureInactiveException($feature);
     }
 
     /**

--- a/tests/Feature/ArrayDriverTest.php
+++ b/tests/Feature/ArrayDriverTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature;
 
 use Closure;
+use function Orchestra\Testbench\workbench_path;
 use Illuminate\Container\Container;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Config;
@@ -17,12 +18,13 @@ use Laravel\Pennant\Events\FeatureUpdated;
 use Laravel\Pennant\Events\FeatureUpdatedForAllScopes;
 use Laravel\Pennant\Events\UnexpectedNullScopeEncountered;
 use Laravel\Pennant\Events\UnknownFeatureResolved;
+use Laravel\Pennant\Exceptions\FeatureInactiveException;
 use Laravel\Pennant\Feature;
+use Rector\Php70\Rector\MethodCall\ThisCallOnStaticMethodToStaticCallRector;
 use RuntimeException;
 use Tests\TestCase;
-use Workbench\App\Models\User;
 
-use function Orchestra\Testbench\workbench_path;
+use Workbench\App\Models\User;
 
 class ArrayDriverTest extends TestCase
 {
@@ -1177,6 +1179,17 @@ class ArrayDriverTest extends TestCase
         $feature = Feature::instance('lottery-based-feature');
         $this->assertInstanceOf(Lottery::class, $feature);
         $this->assertSame('345', $feature());
+    }
+
+    public function test_exception_is_thrown_if_feature_is_inactive(): void
+    {
+        Feature::define('foo', fn () => true);
+        Feature::define('bar', fn () => false);
+
+        $this->assertTrue(Feature::activeOrFail('foo'));
+
+        $this->expectException(FeatureInactiveException::class);
+        Feature::activeOrFail('bar');
     }
 }
 

--- a/tests/Feature/DatabaseDriverTest.php
+++ b/tests/Feature/DatabaseDriverTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature;
 
 use Exception;
+use function Orchestra\Testbench\workbench_path;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Database\Events\QueryExecuted;
 use Illuminate\Database\UniqueConstraintViolationException;
@@ -23,13 +24,13 @@ use Laravel\Pennant\Events\FeatureUpdated;
 use Laravel\Pennant\Events\FeatureUpdatedForAllScopes;
 use Laravel\Pennant\Events\UnexpectedNullScopeEncountered;
 use Laravel\Pennant\Events\UnknownFeatureResolved;
+use Laravel\Pennant\Exceptions\FeatureInactiveException;
 use Laravel\Pennant\Feature;
 use RuntimeException;
 use Tests\TestCase;
 use Workbench\App\Models\User;
-use Workbench\Database\Factories\UserFactory;
 
-use function Orchestra\Testbench\workbench_path;
+use Workbench\Database\Factories\UserFactory;
 
 class DatabaseDriverTest extends TestCase
 {
@@ -1567,6 +1568,17 @@ class DatabaseDriverTest extends TestCase
             'value' => 'true',
             'name' => 'foo',
         ], $records[3]);
+    }
+
+    public function test_exception_is_thrown_if_feature_is_inactive(): void
+    {
+        Feature::define('foo', fn () => true);
+        Feature::define('bar', fn () => false);
+
+        $this->assertTrue(Feature::activeOrFail('foo'));
+
+        $this->expectException(FeatureInactiveException::class);
+        Feature::activeOrFail('bar');
     }
 }
 


### PR DESCRIPTION
Adds a new `activeOrFail` (taking the naming convention from Eloquent models) method to check if a feature is active, throwing an exception if it isn’t.

The motivation for this method is to reduce the need of conditionals when feature-flagging code paths. For example, a queued job that can only be queued if a specific feature is active. Before, I’d have something like this:

```php
public function __construct(User $user)
{
    if (Feature::inactive('feature-v2')) {
        throw new RuntimeException('Feature [feature-v2] is not active.');
    }

    $this->user = $user;
}
```

With the new method, this can now be simplified to:

```diff
  public function __construct(User $user)
  {
-     if (Feature::inactive('feature-v2')) {
-         throw new RuntimeException('Feature [feature-v2] is not active.');
-     }
+     Feature::activeOrFail('feature-v2');

      $this->user = $user;
  }
```