### PR TITLE
[1.x] Allow control over feature serialization

### DIFF
--- a/src/Contracts/FeatureScopeSerializeable.php
+++ b/src/Contracts/FeatureScopeSerializeable.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Laravel\Pennant\Contracts;
+
+interface FeatureScopeSerializeable
+{
+    /**
+     * Serialize the feature scope for storage.
+     */
+    public function featureScopeSerialize(string $driver): string;
+}

--- a/src/Contracts/FeatureScopeSerializeable.php
+++ b/src/Contracts/FeatureScopeSerializeable.php
@@ -7,5 +7,5 @@ interface FeatureScopeSerializeable
     /**
      * Serialize the feature scope for storage.
      */
-    public function featureScopeSerialize(string $driver): string;
+    public function featureScopeSerialize(): string;
 }

--- a/src/Drivers/Decorator.php
+++ b/src/Drivers/Decorator.php
@@ -329,7 +329,7 @@ class Decorator implements CanListStoredFeatures, Driver
         $scope = $this->resolveScope($scope);
 
         $item = $this->cache
-            ->whereStrict('scope', Feature::serializeScope($scope))
+            ->whereStrict('scope', Feature::serializeScope($scope, $this->name))
             ->whereStrict('feature', $feature)
             ->first();
 
@@ -585,7 +585,7 @@ class Decorator implements CanListStoredFeatures, Driver
      */
     protected function isCached($feature, $scope)
     {
-        $scope = Feature::serializeScope($scope);
+        $scope = Feature::serializeScope($scope, $this->name, $this->name, $this->name, $this->name, $this->name, $this->name, $this->name, $this->name);
 
         return $this->cache->search(
             fn ($item) => $item['feature'] === $feature && $item['scope'] === $scope
@@ -602,7 +602,7 @@ class Decorator implements CanListStoredFeatures, Driver
      */
     protected function putInCache($feature, $scope, $value)
     {
-        $scope = Feature::serializeScope($scope);
+        $scope = Feature::serializeScope($scope, $this->name);
 
         $position = $this->cache->search(
             fn ($item) => $item['feature'] === $feature && $item['scope'] === $scope
@@ -624,7 +624,7 @@ class Decorator implements CanListStoredFeatures, Driver
      */
     protected function removeFromCache($feature, $scope)
     {
-        $scope = Feature::serializeScope($scope);
+        $scope = Feature::serializeScope($scope, $this->name);
 
         $position = $this->cache->search(
             fn ($item) => $item['feature'] === $feature && $item['scope'] === $scope

--- a/src/Drivers/Decorator.php
+++ b/src/Drivers/Decorator.php
@@ -329,7 +329,7 @@ class Decorator implements CanListStoredFeatures, Driver
         $scope = $this->resolveScope($scope);
 
         $item = $this->cache
-            ->whereStrict('scope', Feature::serializeScope($scope, $this->name))
+            ->whereStrict('scope', Feature::serializeScope($scope))
             ->whereStrict('feature', $feature)
             ->first();
 
@@ -585,7 +585,7 @@ class Decorator implements CanListStoredFeatures, Driver
      */
     protected function isCached($feature, $scope)
     {
-        $scope = Feature::serializeScope($scope, $this->name, $this->name, $this->name, $this->name, $this->name, $this->name, $this->name, $this->name);
+        $scope = Feature::serializeScope($scope);
 
         return $this->cache->search(
             fn ($item) => $item['feature'] === $feature && $item['scope'] === $scope
@@ -602,7 +602,7 @@ class Decorator implements CanListStoredFeatures, Driver
      */
     protected function putInCache($feature, $scope, $value)
     {
-        $scope = Feature::serializeScope($scope, $this->name);
+        $scope = Feature::serializeScope($scope);
 
         $position = $this->cache->search(
             fn ($item) => $item['feature'] === $feature && $item['scope'] === $scope
@@ -624,7 +624,7 @@ class Decorator implements CanListStoredFeatures, Driver
      */
     protected function removeFromCache($feature, $scope)
     {
-        $scope = Feature::serializeScope($scope, $this->name);
+        $scope = Feature::serializeScope($scope);
 
         $position = $this->cache->search(
             fn ($item) => $item['feature'] === $feature && $item['scope'] === $scope

--- a/src/FeatureManager.php
+++ b/src/FeatureManager.php
@@ -7,6 +7,7 @@ use Illuminate\Contracts\Container\Container;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
 use InvalidArgumentException;
+use Laravel\Pennant\Contracts\FeatureScopeSerializeable;
 use Laravel\Pennant\Drivers\ArrayDriver;
 use Laravel\Pennant\Drivers\DatabaseDriver;
 use Laravel\Pennant\Drivers\Decorator;
@@ -178,17 +179,19 @@ class FeatureManager
      * Serialize the given scope for storage.
      *
      * @param  mixed  $scope
+     * @param  string  $driver
      * @return string|null
      */
-    public function serializeScope($scope)
+    public function serializeScope($scope, $driver = '')
     {
         return match (true) {
+            $scope instanceof FeatureScopeSerializeable => $scope->featureScopeSerialize($driver),
             $scope === null => '__laravel_null',
             is_string($scope) => $scope,
             is_numeric($scope) => (string) $scope,
             $scope instanceof Model && $this->useMorphMap => $scope->getMorphClass().'|'.$scope->getKey(),
             $scope instanceof Model && ! $this->useMorphMap => $scope::class.'|'.$scope->getKey(),
-            default => throw new RuntimeException('Unable to serialize the feature scope to a string. You should implement the FeatureScopeable contract.')
+            default => throw new RuntimeException('Unable to serialize the feature scope to a string. You should implement the FeatureScopeSerializeable contract.')
         };
     }
 

--- a/src/FeatureManager.php
+++ b/src/FeatureManager.php
@@ -179,13 +179,12 @@ class FeatureManager
      * Serialize the given scope for storage.
      *
      * @param  mixed  $scope
-     * @param  string  $driver
-     * @return string|null
+     * @return string
      */
-    public function serializeScope($scope, $driver = '')
+    public function serializeScope($scope)
     {
         return match (true) {
-            $scope instanceof FeatureScopeSerializeable => $scope->featureScopeSerialize($driver),
+            $scope instanceof FeatureScopeSerializeable => $scope->featureScopeSerialize(),
             $scope === null => '__laravel_null',
             is_string($scope) => $scope,
             is_numeric($scope) => (string) $scope,

--- a/tests/Feature/DatabaseDriverTest.php
+++ b/tests/Feature/DatabaseDriverTest.php
@@ -14,6 +14,7 @@ use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Str;
 use InvalidArgumentException;
 use Laravel\Pennant\Contracts\FeatureScopeable;
+use Laravel\Pennant\Contracts\FeatureScopeSerializeable;
 use Laravel\Pennant\Events\AllFeaturesPurged;
 use Laravel\Pennant\Events\DynamicallyRegisteringFeatureClass;
 use Laravel\Pennant\Events\FeatureDeleted;
@@ -356,21 +357,27 @@ class DatabaseDriverTest extends TestCase
 
     public function test_it_can_handle_feature_scopeable_objects()
     {
-        $scopeable = fn () => new class extends User implements FeatureScopeable
+        Feature::define('foo', function ($scope) {
+            return $scope === 'tim@laravel.com';
+        });
+        $scopeable = fn ($email) => new class(['email' => $email]) extends User implements FeatureScopeable
         {
             public function toFeatureIdentifier($driver): mixed
             {
-                return 'tim@laravel.com';
+                return $this->email;
             }
         };
 
-        Feature::for($scopeable())->activate('foo');
+        $this->assertTrue(Feature::for($scopeable('tim@laravel.com'))->active('foo'));
+        $this->assertFalse(Feature::for($scopeable('james@laravel.com'))->active('foo'));
 
-        $this->assertFalse(Feature::for('james@laravel.com')->active('foo'));
-        $this->assertTrue(Feature::for('tim@laravel.com')->active('foo'));
-        $this->assertTrue(Feature::for($scopeable())->active('foo'));
+        $this->assertCount(4, DB::getQueryLog());
 
-        $this->assertCount(2, DB::getQueryLog());
+        $scope = DB::table('features')->get('scope');
+        $this->assertSame([
+            'james@laravel.com',
+            'tim@laravel.com',
+        ], $scope->pluck('scope')->all());
     }
 
     public function test_it_serializes_eloquent_models()
@@ -380,6 +387,31 @@ class DatabaseDriverTest extends TestCase
         $scope = DB::table('features')->value('scope');
 
         $this->assertStringContainsString('Workbench\App\Models\User|1', $scope);
+    }
+
+    public function test_it_can_manually_serialize_scope()
+    {
+        Feature::define('foo', function ($scope) {
+            return $scope->email === 'tim@laravel.com';
+        });
+        $scopeable = fn ($email) => new class(['email' => $email]) extends User implements FeatureScopeSerializeable
+        {
+            public function featureScopeSerialize(string $driver): string
+            {
+                return $this->email;
+            }
+        };
+
+        $this->assertTrue(Feature::for($scopeable('tim@laravel.com'))->active('foo'));
+        $this->assertFalse(Feature::for($scopeable('james@laravel.com'))->active('foo'));
+
+        $this->assertCount(4, DB::getQueryLog());
+
+        $scope = DB::table('features')->get('scope');
+        $this->assertSame([
+            'james@laravel.com',
+            'tim@laravel.com',
+        ], $scope->pluck('scope')->all());
     }
 
     public function test_it_can_load_feature_state_into_memory()

--- a/tests/Feature/DatabaseDriverTest.php
+++ b/tests/Feature/DatabaseDriverTest.php
@@ -396,7 +396,7 @@ class DatabaseDriverTest extends TestCase
         });
         $scopeable = fn ($email) => new class(['email' => $email]) extends User implements FeatureScopeSerializeable
         {
-            public function featureScopeSerialize(string $driver): string
+            public function featureScopeSerialize(): string
             {
                 return $this->email;
             }


### PR DESCRIPTION
This PR adds a contract that objects may implement to control how they are serialized.

This is kinda already possible via the existing `FeatureScopeable` interface but is not really the intention of that contract.

The exciting `FeatureScopeable` interface allows you to return a value, which may be an object or a scalar, that represents the scope. This value is passed to the feature resolver.

```php
Feature::define('foo', function (string $email) {
    return str_ends_with($email, '@laravel.com');
});

class Foo implements FeatureScopeable
{
    public function toFeatureIdentifier(string $driver): mixed
    {
        return $this->email;
    }
}
```

With the above in place we can now call `Feature::active($user)` and the feature resolver will receive the user's email address. The email address also ends up stored in the database.

But what if you want to be able to pass in the entire user object and still control how the object is serialized? This is where the new contract comes in.

```php
Feature::define('foo', function (User $user) {
    return $user->isAdmin() || str_ends_with($user->email, '@laravel.com');
});

class Foo implements FeatureScopeSerializable
{
    public function featureScopeSerialize(): mixed
    {
        return $this->email;
    }
}
```

Now the feature resolver will receive the user object, not the email. However, the email will end up stored in the database.

One contract does not necessarily replace the other. I can imagine a set up where objects return a rich object from `toFeatureIdentifier` which then implements the `FeatureScopeSerializable` contract.

### Naming

I matched PHP's `JsonSerializable` interface naming for this.

`interface JsonSerializable` => `interfaceFeatureScopeSerializable`
`function jsonSerialize()` => `function featureScopeSerialize()`