### PR TITLE
[1.x] Allow external drivers to retrieve defined features for the given scope

### DIFF
--- a/src/Contracts/DefinesFeaturesExternally.php
+++ b/src/Contracts/DefinesFeaturesExternally.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Laravel\Pennant\Contracts;
+
+interface DefinesFeaturesExternally
+{
+    /**
+     * Retrieve the defined features for the given scope.
+     *
+     * @return list<string>
+     */
+    public function definedFeaturesForScope(mixed $scope): array;
+}

--- a/src/Drivers/Decorator.php
+++ b/src/Drivers/Decorator.php
@@ -10,6 +10,7 @@ use Illuminate\Support\Lottery;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Macroable;
 use Laravel\Pennant\Contracts\CanListStoredFeatures;
+use Laravel\Pennant\Contracts\DefinesFeaturesExternally;
 use Laravel\Pennant\Contracts\Driver;
 use Laravel\Pennant\Contracts\FeatureScopeable;
 use Laravel\Pennant\Events\AllFeaturesPurged;
@@ -620,6 +621,10 @@ class Decorator implements CanListStoredFeatures, Driver
      */
     public function definedFeaturesForScope($scope)
     {
+        if ($this->driver instanceof DefinesFeaturesExternally) {
+            return collect($this->driver->definedFeaturesForScope($scope));
+        }
+
         return collect($this->nameMap)
             ->only($this->defined())
             ->filter(function ($resolver) use ($scope) {

--- a/src/Drivers/Decorator.php
+++ b/src/Drivers/Decorator.php
@@ -621,6 +621,8 @@ class Decorator implements CanListStoredFeatures, Driver
      */
     public function definedFeaturesForScope($scope)
     {
+        $scope = $this->resolveScope($scope);
+
         if ($this->driver instanceof DefinesFeaturesExternally) {
             return collect($this->driver->definedFeaturesForScope($scope));
         }

--- a/tests/Feature/DefinesFeaturesExternallyTest.php
+++ b/tests/Feature/DefinesFeaturesExternallyTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature;
 
 use Illuminate\Support\Facades\Config;
 use Laravel\Pennant\Contracts\DefinesFeaturesExternally;
+use Laravel\Pennant\Contracts\FeatureScopeable;
 use Laravel\Pennant\Drivers\ArrayDriver;
 use Laravel\Pennant\Feature;
 use Tests\TestCase;
@@ -35,6 +36,38 @@ class DefinesFeaturesExternallyTest extends TestCase
         $this->assertSame([
             'feature-1' => false,
             'feature-2' => false,
+        ], $features);
+    }
+
+    public function test_when_features_are_defined_externally_that_scope_is_correctly_resolved()
+    {
+        $driver = new class(app('events'), []) extends ArrayDriver implements DefinesFeaturesExternally
+        {
+            /**
+             * Retrieve the defined features for the given scope.
+             *
+             * @return list<string>
+             */
+            public function definedFeaturesForScope(mixed $scope): array
+            {
+                return [
+                    $scope,
+                ];
+            }
+        };
+        Feature::extend('external', fn () => $driver);
+        Config::set('pennant.stores.external', ['driver' => 'external']);
+
+        $features = Feature::driver('external')->for(new class implements FeatureScopeable
+        {
+            public function toFeatureIdentifier(string $driver): mixed
+            {
+                return 'scope-value';
+            }
+        })->all();
+
+        $this->assertSame([
+            'scope-value' => false,
         ], $features);
     }
 }

--- a/tests/Feature/DefinesFeaturesExternallyTest.php
+++ b/tests/Feature/DefinesFeaturesExternallyTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Support\Facades\Config;
+use Laravel\Pennant\Contracts\DefinesFeaturesExternally;
+use Laravel\Pennant\Drivers\ArrayDriver;
+use Laravel\Pennant\Feature;
+use Tests\TestCase;
+
+class DefinesFeaturesExternallyTest extends TestCase
+{
+    public function test_it_can_retrieve_all_features_when_features_are_defined_externally()
+    {
+        $driver = new class(app('events'), []) extends ArrayDriver implements DefinesFeaturesExternally
+        {
+            /**
+             * Retrieve the defined features for the given scope.
+             *
+             * @return list<string>
+             */
+            public function definedFeaturesForScope(mixed $scope): array
+            {
+                return [
+                    'feature-1',
+                    'feature-2',
+                ];
+            }
+        };
+        Feature::extend('external', fn () => $driver);
+        Config::set('pennant.stores.external', ['driver' => 'external']);
+
+        $features = Feature::driver('external')->all();
+
+        $this->assertSame([
+            'feature-1' => false,
+            'feature-2' => false,
+        ], $features);
+    }
+}
+

--- a/tests/Feature/DefinesFeaturesExternallyTest.php
+++ b/tests/Feature/DefinesFeaturesExternallyTest.php
@@ -38,4 +38,3 @@ class DefinesFeaturesExternallyTest extends TestCase
         ], $features);
     }
 }
-


### PR DESCRIPTION
This PR introduces a new interface that allows 3rd party drivers that define features in their own platform to provide a list of features for the given scope.

One of the nice things about Pennant is it has support for 3rd party drivers, such as LaunchDarkly. When using an external driver where the features are defined in a different system, it is not currently possible to retrieve the features for a given user with the recent improvements made to the `Feature::all()` functionality.

This PR introduces a new interface allowing them to provide a feature list if they wish.