### PR TITLE
[1.x] Add before hook support to features with names

### DIFF
--- a/src/Drivers/DatabaseDriver.php
+++ b/src/Drivers/DatabaseDriver.php
@@ -158,7 +158,7 @@ class DatabaseDriver implements CanListStoredFeatures, Driver
             $filtered = $records->where('name', $feature)->where('scope', Feature::serializeScope($scope));
 
             if ($filtered->isNotEmpty()) {
-                return json_decode($filtered->value('value'), flags: JSON_OBJECT_AS_ARRAY | JSON_THROW_ON_ERROR);
+                return json_decode($filtered->value('value'), flags: JSON_OBJECT_AS_ARRAY | JSON_THROW_ON_ERROR); // @phpstan-ignore argument.type
             }
 
             return with($this->resolveValue($feature, $scope), function ($value) use ($feature, $scope, $inserts) {

--- a/tests/Feature/FeatureHelperTest.php
+++ b/tests/Feature/FeatureHelperTest.php
@@ -15,20 +15,20 @@ class FeatureHelperTest extends TestCase
         Config::set('pennant.default', 'array');
     }
 
-    public function testItReturnsFeatureManager()
+    public function test_it_returns_feature_manager()
     {
         $this->assertNotNull(feature());
         $this->assertSame(Feature::getFacadeRoot(), feature());
     }
 
-    public function testItReturnsTheFeatureValue()
+    public function test_it_returns_the_feature_value()
     {
         Feature::activate('foo', 'bar');
 
         $this->assertSame('bar', feature('foo'));
     }
 
-    public function testItConditionallyExecutesCodeBlocks()
+    public function test_it_conditionally_executes_code_blocks()
     {
         Feature::activate('foo');
         $inactive = $active = null;

--- a/tests/IntersectionTypeTest.php
+++ b/tests/IntersectionTypeTest.php
@@ -24,7 +24,7 @@ class IntersectionTypeTest extends TestCase
         DB::enableQueryLog();
     }
 
-    public function testCanRetrieveAllFeaturesForDifferingScopeTypes(): void
+    public function test_can_retrieve_all_features_for_differing_scope_types(): void
     {
         Feature::define('user', fn (User $user) => 1);
         Feature::define('nullable-user', fn (?User $user) => 2);


### PR DESCRIPTION
This PR adds `before` hook support to features with custom names.

fixes #129 

A feature `before` hook fires before we hit the database, allowing runtime interception of feature checks. This feature is not currently supported for features with custom names, e.g., 

```php
class MyFeature
{
    public $name = 'my-feature';

    // ...
}
```

