### PR TITLE
[1.x] Allow any driver to opt-in to cache flushing

### DIFF
--- a/src/Contracts/FlushableCache.php
+++ b/src/Contracts/FlushableCache.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Laravel\Pennant\Contracts;
+
+interface FlushableCache
+{
+    /**
+     * Flush the cache.
+     *
+     * @return void
+     */
+    public function flushCache();
+}

--- a/src/Contracts/HasFlushableCache.php
+++ b/src/Contracts/HasFlushableCache.php
@@ -2,7 +2,7 @@
 
 namespace Laravel\Pennant\Contracts;
 
-interface FlushableCache
+interface HasFlushableCache
 {
     /**
      * Flush the cache.

--- a/src/Drivers/ArrayDriver.php
+++ b/src/Drivers/ArrayDriver.php
@@ -6,12 +6,12 @@ use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Support\Collection;
 use Laravel\Pennant\Contracts\CanListStoredFeatures;
 use Laravel\Pennant\Contracts\Driver;
-use Laravel\Pennant\Contracts\FlushableCache;
+use Laravel\Pennant\Contracts\HasFlushableCache;
 use Laravel\Pennant\Events\UnknownFeatureResolved;
 use Laravel\Pennant\Feature;
 use stdClass;
 
-class ArrayDriver implements CanListStoredFeatures, Driver, FlushableCache
+class ArrayDriver implements CanListStoredFeatures, Driver, HasFlushableCache
 {
     /**
      * The event dispatcher.

--- a/src/Drivers/ArrayDriver.php
+++ b/src/Drivers/ArrayDriver.php
@@ -6,11 +6,12 @@ use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Support\Collection;
 use Laravel\Pennant\Contracts\CanListStoredFeatures;
 use Laravel\Pennant\Contracts\Driver;
+use Laravel\Pennant\Contracts\FlushableCache;
 use Laravel\Pennant\Events\UnknownFeatureResolved;
 use Laravel\Pennant\Feature;
 use stdClass;
 
-class ArrayDriver implements CanListStoredFeatures, Driver
+class ArrayDriver implements CanListStoredFeatures, Driver, FlushableCache
 {
     /**
      * The event dispatcher.

--- a/src/Drivers/Decorator.php
+++ b/src/Drivers/Decorator.php
@@ -13,7 +13,7 @@ use Laravel\Pennant\Contracts\CanListStoredFeatures;
 use Laravel\Pennant\Contracts\DefinesFeaturesExternally;
 use Laravel\Pennant\Contracts\Driver;
 use Laravel\Pennant\Contracts\FeatureScopeable;
-use Laravel\Pennant\Contracts\FlushableCache;
+use Laravel\Pennant\Contracts\HasFlushableCache;
 use Laravel\Pennant\Events\AllFeaturesPurged;
 use Laravel\Pennant\Events\DynamicallyRegisteringFeatureClass;
 use Laravel\Pennant\Events\FeatureDeleted;
@@ -37,7 +37,7 @@ use Symfony\Component\Finder\Finder;
 /**
  * @mixin \Laravel\Pennant\PendingScopedFeatureInteraction
  */
-class Decorator implements CanListStoredFeatures, Driver, FlushableCache
+class Decorator implements CanListStoredFeatures, Driver, HasFlushableCache
 {
     use Macroable {
         __call as macroCall;
@@ -803,7 +803,7 @@ class Decorator implements CanListStoredFeatures, Driver, FlushableCache
     {
         $this->cache = new Collection;
 
-        if ($this->driver instanceof FlushableCache) {
+        if ($this->driver instanceof HasFlushableCache) {
             $this->driver->flushCache();
         }
     }

--- a/src/Drivers/Decorator.php
+++ b/src/Drivers/Decorator.php
@@ -13,6 +13,7 @@ use Laravel\Pennant\Contracts\CanListStoredFeatures;
 use Laravel\Pennant\Contracts\DefinesFeaturesExternally;
 use Laravel\Pennant\Contracts\Driver;
 use Laravel\Pennant\Contracts\FeatureScopeable;
+use Laravel\Pennant\Contracts\FlushableCache;
 use Laravel\Pennant\Events\AllFeaturesPurged;
 use Laravel\Pennant\Events\DynamicallyRegisteringFeatureClass;
 use Laravel\Pennant\Events\FeatureDeleted;
@@ -36,7 +37,7 @@ use Symfony\Component\Finder\Finder;
 /**
  * @mixin \Laravel\Pennant\PendingScopedFeatureInteraction
  */
-class Decorator implements CanListStoredFeatures, Driver
+class Decorator implements CanListStoredFeatures, Driver, FlushableCache
 {
     use Macroable {
         __call as macroCall;
@@ -801,6 +802,10 @@ class Decorator implements CanListStoredFeatures, Driver
     public function flushCache()
     {
         $this->cache = new Collection;
+
+        if ($this->driver instanceof FlushableCache) {
+            $this->driver->flushCache();
+        }
     }
 
     /**

--- a/src/FeatureManager.php
+++ b/src/FeatureManager.php
@@ -217,10 +217,6 @@ class FeatureManager
         foreach ($this->stores as $driver) {
             $driver->flushCache();
         }
-
-        if (isset($this->stores['array'])) {
-            $this->stores['array']->getDriver()->flushCache();
-        }
     }
 
     /**


### PR DESCRIPTION
Currently there is a special case with the `ArrayDriver` that will flush it's internal driver cache when calling `Feature::flushCache()` — this PR adds a `FlushableCache` interface which makes it possible for any driver to opt-in to this behavior.