### PR TITLE
Ensure migrations use the correct configured database connection

### DIFF
--- a/database/migrations/2022_11_01_000001_create_features_table.php
+++ b/database/migrations/2022_11_01_000001_create_features_table.php
@@ -37,7 +37,7 @@ return new class extends Migration
     /**
      * Get the migration connection name.
      *
-     * @return string|null
+     * @return string
      */
     public function getConnection()
     {

--- a/database/migrations/2022_11_01_000001_create_features_table.php
+++ b/database/migrations/2022_11_01_000001_create_features_table.php
@@ -1,10 +1,10 @@
 <?php
 
-use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
+use Laravel\Pennant\Migrations\PennantMigration;
 
-return new class extends Migration
+return new class extends PennantMigration
 {
     /**
      * Run the migrations.
@@ -32,17 +32,5 @@ return new class extends Migration
     public function down()
     {
         Schema::dropIfExists('features');
-    }
-
-    /**
-     * Get the migration connection name.
-     *
-     * @return string
-     */
-    public function getConnection()
-    {
-        $connection = config('pennant.stores.database.connection');
-
-        return ($connection === null || $connection === 'null') ? config('database.default') : $connection;
     }
 };

--- a/database/migrations/2022_11_01_000001_create_features_table.php
+++ b/database/migrations/2022_11_01_000001_create_features_table.php
@@ -33,4 +33,16 @@ return new class extends Migration
     {
         Schema::dropIfExists('features');
     }
+
+    /**
+     * Get the migration connection name.
+     *
+     * @return string|null
+     */
+    public function getConnection()
+    {
+        $connection = config('pennant.stores.database.connection');
+
+        return ($connection === null || $connection === 'null') ? config('database.default') : $connection;
+    }
 };

--- a/src/Migrations/PennantMigration.php
+++ b/src/Migrations/PennantMigration.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Laravel\Pennant\Migrations;
+
+use Illuminate\Database\Migrations\Migration;
+
+abstract class PennantMigration extends Migration
+{
+    /**
+     * Get the migration connection name.
+     *
+     * @return string
+     */
+    public function getConnection()
+    {
+        $connection = config('pennant.stores.database.connection');
+
+        return ($connection === null || $connection === 'null') ? config('database.default') : $connection;
+    }
+}

--- a/tests/Feature/DatabaseDriverTest.php
+++ b/tests/Feature/DatabaseDriverTest.php
@@ -1210,6 +1210,22 @@ class DatabaseDriverTest extends TestCase
         $this->assertSame('bar_features', $tableResolver->bindTo($driver, $driver)());
     }
 
+    public function test_it_uses_default_connection_if_null()
+    {
+        Config::set('pennant.stores.database.connection', 'null');
+
+        $migration = new class extends \Illuminate\Database\Migrations\Migration {
+            public function getConnection()
+            {
+                $connection = config('pennant.stores.database.connection');
+                return ($connection === null || $connection === 'null') ? config('database.default') : $connection;
+            }
+        };
+
+        $connection = $migration->getConnection();
+        $this->assertSame(config('database.default'), $connection);
+    }
+
     public function test_it_dispatches_events_when_purging_features()
     {
         Event::fake([FeaturesPurged::class]);


### PR DESCRIPTION
This PR ensures that the migration for Pennant use the configured database connection.

### Why is this needed?
Currently, the migration does not explicitly set the database connection, which causes issues when using a custom connection for Pennant. As a result, migrations may run on the default connection instead of the intended one.

### How does this fix it?

- Uses `getConnection()` to ensure the migration runs on the correct database connection.
- Ensures compatibility for multi-database setups.

Let me know if any adjustments are needed.