### PR TITLE
Enhancement: Restorable Rich Feature Values

### DIFF
--- a/database/migrations/2025_02_23_000001_add_active_column_to_features_table.php
+++ b/database/migrations/2025_02_23_000001_add_active_column_to_features_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Laravel\Pennant\Migrations\PennantMigration;
+
+return new class extends PennantMigration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('features', function (Blueprint $table) {
+            $table->boolean('active')->after('value')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('features', function (Blueprint $table) {
+            $table->dropColumn('active');
+        });
+    }
+};

--- a/src/Contracts/Driver.php
+++ b/src/Contracts/Driver.php
@@ -37,9 +37,19 @@ interface Driver
     public function set(string $feature, mixed $scope, mixed $value): void;
 
     /**
+     * Restore a feature flag's value.
+     */
+    public function restore(string $feature, mixed $scope, mixed $value): void;
+
+    /**
      * Set a feature flag's value for all scopes.
      */
     public function setForAllScopes(string $feature, mixed $value): void;
+
+    /**
+     * Restore a feature flag's value for all scopes.
+     */
+    public function restoreForAllScopes(string $feature, mixed $fallback): void;
 
     /**
      * Delete a feature flag's value.

--- a/src/Drivers/ArrayDriver.php
+++ b/src/Drivers/ArrayDriver.php
@@ -174,6 +174,30 @@ class ArrayDriver implements CanListStoredFeatures, Driver, HasFlushableCache
     }
 
     /**
+     * Restore the value for the given feature and scope.
+     *
+     * @param  string  $feature
+     * @param  mixed  $scope
+     * @param  mixed  $fallback
+     * @return void
+     */
+    public function restore($feature, $scope, $fallback = true): void
+    {
+        $this->set($feature, $scope, $fallback);
+    }
+
+    /**
+     * Restore feature flag's value for all scopes.
+     *
+     * @param  string  $feature
+     * @param  mixed  $value
+     */
+    public function restoreForAllScopes($feature, $fallback): void
+    {
+        $this->setForAllScopes($feature, $fallback);
+    }
+
+    /**
      * Delete a feature flag's value.
      *
      * @param  string  $feature

--- a/src/Drivers/ArrayDriver.php
+++ b/src/Drivers/ArrayDriver.php
@@ -190,7 +190,7 @@ class ArrayDriver implements CanListStoredFeatures, Driver, HasFlushableCache
      * Restore feature flag's value for all scopes.
      *
      * @param  string  $feature
-     * @param  mixed  $value
+     * @param  mixed  $fallback
      */
     public function restoreForAllScopes($feature, $fallback): void
     {

--- a/src/Drivers/DatabaseDriver.php
+++ b/src/Drivers/DatabaseDriver.php
@@ -395,7 +395,6 @@ class DatabaseDriver implements CanListStoredFeatures, Driver
      * Restore a feature flag's values for all scopes.
      *
      * @param  string  $feature
-     * @param  mixed  $scope
      * @param  mixed  $fallback
      * @return void
      */

--- a/src/Drivers/DatabaseDriver.php
+++ b/src/Drivers/DatabaseDriver.php
@@ -158,7 +158,7 @@ class DatabaseDriver implements CanListStoredFeatures, Driver
             $filtered = $records->where('name', $feature)->where('scope', Feature::serializeScope($scope));
 
             if ($filtered->isNotEmpty()) {
-                return json_decode($filtered->value('value'), flags: JSON_OBJECT_AS_ARRAY | JSON_THROW_ON_ERROR); // @phpstan-ignore argument.type
+                return $this->value($filtered->first());
             }
 
             return with($this->resolveValue($feature, $scope), function ($value) use ($feature, $scope, $inserts) {
@@ -196,6 +196,22 @@ class DatabaseDriver implements CanListStoredFeatures, Driver
     }
 
     /**
+     * Get the feature record's value
+     * 
+     * @param object $record
+     */
+    protected function value(object $record): mixed
+    {
+        $value = json_decode($record->value, flags: JSON_OBJECT_AS_ARRAY | JSON_THROW_ON_ERROR);
+
+        if (isset($record->active)) {
+            return (bool) $record->active ? $value : false;
+        }
+
+        return $value;
+    }
+
+    /**
      * Retrieve a feature flag's value.
      *
      * @param  string  $feature
@@ -204,7 +220,7 @@ class DatabaseDriver implements CanListStoredFeatures, Driver
     public function get($feature, $scope): mixed
     {
         if (($record = $this->retrieve($feature, $scope)) !== null) {
-            return json_decode($record->value, flags: JSON_OBJECT_AS_ARRAY | JSON_THROW_ON_ERROR);
+            return $this->value($record);
         }
 
         return with($this->resolveValue($feature, $scope), function ($value) use ($feature, $scope) {
@@ -270,15 +286,41 @@ class DatabaseDriver implements CanListStoredFeatures, Driver
      * @param  mixed  $scope
      * @param  mixed  $value
      */
-    public function set($feature, $scope, $value): void
+    public function set($feature, $scope, $value = null): void
     {
+        if ($value) {
+            $this->newQuery()->upsert([
+                'name' => $feature,
+                'scope' => Feature::serializeScope($scope),
+                'active' => true,
+                'value' => json_encode($value, flags: JSON_THROW_ON_ERROR),
+                static::CREATED_AT => $now = Carbon::now(),
+                static::UPDATED_AT => $now,
+            ], uniqueBy: ['name', 'scope'], update: ['active', 'value', static::UPDATED_AT]);
+
+            return;
+        }
+
+        if (is_null($value)) {
+            $this->newQuery()->upsert([
+                'name' => $feature,
+                'scope' => Feature::serializeScope($scope),
+                'active' => true,
+                static::CREATED_AT => $now = Carbon::now(),
+                static::UPDATED_AT => $now,
+            ], uniqueBy: ['name', 'scope'], update: ['active', static::UPDATED_AT]);
+
+            return;
+        }
+
         $this->newQuery()->upsert([
             'name' => $feature,
             'scope' => Feature::serializeScope($scope),
+            'active' => false,
             'value' => json_encode($value, flags: JSON_THROW_ON_ERROR),
             static::CREATED_AT => $now = Carbon::now(),
             static::UPDATED_AT => $now,
-        ], uniqueBy: ['name', 'scope'], update: ['value', static::UPDATED_AT]);
+        ], uniqueBy: ['name', 'scope'], update: ['active', static::UPDATED_AT]);
     }
 
     /**
@@ -289,12 +331,95 @@ class DatabaseDriver implements CanListStoredFeatures, Driver
      */
     public function setForAllScopes($feature, $value): void
     {
+        if ($value) {
+            $this->newQuery()
+                ->where('name', $feature)
+                ->update([
+                    'active' => true,
+                    'value' => json_encode($value, flags: JSON_THROW_ON_ERROR),
+                    static::UPDATED_AT => Carbon::now(),
+                ]);
+
+            return;
+        }
+
+        if (is_null($value)) {
+            $this->newQuery()
+                ->where('name', $feature)
+                ->update([
+                    'active' => true,
+                    static::UPDATED_AT => Carbon::now(),
+                ]);
+
+            return;
+        }
+
         $this->newQuery()
             ->where('name', $feature)
             ->update([
-                'value' => json_encode($value, flags: JSON_THROW_ON_ERROR),
+                'active' => false,
                 static::UPDATED_AT => Carbon::now(),
             ]);
+    }
+
+    /**
+     * Restore the value for the given feature and scope.
+     *
+     * @param  string  $feature
+     * @param  mixed  $scope
+     * @param  mixed  $fallback
+     * @return void
+     */
+    public function restore($feature, $scope, $fallback = true): void
+    {
+        if (($record = $this->retrieve($feature, $scope)) === null) {
+            return;
+        }
+
+        $values = [
+            'active' => true,
+            static::UPDATED_AT => Carbon::now(),
+        ];
+
+        if (! json_decode($record->value, flags: JSON_OBJECT_AS_ARRAY | JSON_THROW_ON_ERROR)) {
+            $values['value'] = json_encode($fallback, flags: JSON_THROW_ON_ERROR);
+        }
+
+        $this->newQuery()
+            ->where('name', $feature)
+            ->where('scope', Feature::serializeScope($scope))
+            ->update($values);
+    }
+
+    /**
+     * Restore a feature flag's values for all scopes.
+     *
+     * @param  string  $feature
+     * @param  mixed  $scope
+     * @param  mixed  $fallback
+     * @return void
+     */
+    public function restoreForAllScopes($feature, $fallback = true): void
+    {
+        $this->connection()->transaction(function () use ($feature, $fallback) {
+            $this->newQuery()
+                ->where('name', $feature)
+                ->update([
+                    'active' => true,
+                    static::UPDATED_AT => Carbon::now(),
+                ]);
+
+            $this->newQuery()
+                ->where('name', $feature)
+                ->where(function ($query) {
+                    $query->where('value', json_encode(false, flags: JSON_THROW_ON_ERROR))
+                        ->orWhereNull('value');
+                })
+                ->update([
+                    'value' => json_encode($fallback, flags: JSON_THROW_ON_ERROR),
+                    static::UPDATED_AT => Carbon::now(),
+                ]);
+        });
     }
 
     /**
@@ -310,8 +435,12 @@ class DatabaseDriver implements CanListStoredFeatures, Driver
         return (bool) $this->newQuery()
             ->where('name', $feature)
             ->where('scope', Feature::serializeScope($scope))
-            ->update([
+            ->update($value ? [
+                'active' => true,
                 'value' => json_encode($value, flags: JSON_THROW_ON_ERROR),
+                static::UPDATED_AT => Carbon::now(),
+            ]:[
+                'active' => false,
                 static::UPDATED_AT => Carbon::now(),
             ]);
     }
@@ -347,6 +476,7 @@ class DatabaseDriver implements CanListStoredFeatures, Driver
             'name' => $insert['name'],
             'scope' => Feature::serializeScope($insert['scope']),
             'value' => json_encode($insert['value'], flags: JSON_THROW_ON_ERROR),
+            'active' => $insert['value'] ? true : false,
             static::CREATED_AT => $now,
             static::UPDATED_AT => $now,
         ], $inserts));

--- a/src/Drivers/Decorator.php
+++ b/src/Drivers/Decorator.php
@@ -18,6 +18,8 @@ use Laravel\Pennant\Events\AllFeaturesPurged;
 use Laravel\Pennant\Events\DynamicallyRegisteringFeatureClass;
 use Laravel\Pennant\Events\FeatureDeleted;
 use Laravel\Pennant\Events\FeatureResolved;
+use Laravel\Pennant\Events\FeatureRestored;
+use Laravel\Pennant\Events\FeatureRestoredForAllScopes;
 use Laravel\Pennant\Events\FeatureRetrieved;
 use Laravel\Pennant\Events\FeaturesPurged;
 use Laravel\Pennant\Events\FeatureUpdated;
@@ -486,6 +488,28 @@ class Decorator implements CanListStoredFeatures, Driver, HasFlushableCache
     }
 
     /**
+     * Restore a feature flag's value.
+     *
+     * @internal
+     *
+     * @param  string  $feature
+     * @param  mixed  $scope
+     * @param  mixed  $fallback
+     */
+    public function restore($feature, $scope, $fallback = true): void
+    {
+        $feature = $this->resolveFeature($feature);
+
+        $scope = $this->resolveScope($scope);
+
+        $this->driver->restore($feature, $scope, $fallback);
+
+        $this->putInCache($feature, $scope, $this->driver->get($feature, $scope));
+
+        Event::dispatch(new FeatureRestored($feature, $scope, $fallback));
+    }
+
+    /**
      * Activate the feature for everyone.
      *
      * @param  string|array<string>  $feature
@@ -496,6 +520,19 @@ class Decorator implements CanListStoredFeatures, Driver, HasFlushableCache
     {
         Collection::wrap($feature)
             ->each(fn ($name) => $this->setForAllScopes($name, $value));
+    }
+
+    /**
+     * Restore the feature for everyone.
+     *
+     * @param  string|array<string>  $feature
+     * @param  mixed  $fallback
+     * @return void
+     */
+    public function restoreForEveryone($feature, $fallback = true)
+    {
+        Collection::wrap($feature)
+            ->each(fn ($name) => $this->restoreForAllScopes($name, $fallback));
     }
 
     /**
@@ -529,6 +566,27 @@ class Decorator implements CanListStoredFeatures, Driver, HasFlushableCache
         );
 
         Event::dispatch(new FeatureUpdatedForAllScopes($feature, $value));
+    }
+
+    /**
+     * Restore a feature flag's values for all scopes.
+     *
+     * @internal
+     *
+     * @param  string  $feature
+     * @param  mixed  $fallback
+     */
+    public function restoreForAllScopes($feature, $fallback): void
+    {
+        $feature = $this->resolveFeature($feature);
+
+        $this->driver->restoreForAllScopes($feature, $fallback);
+
+        $this->cache = $this->cache->reject(
+            fn ($item) => $item['feature'] === $feature
+        );
+
+        Event::dispatch(new FeatureRestoredForAllScopes($feature, $fallback));
     }
 
     /**

--- a/src/Events/FeatureRestored.php
+++ b/src/Events/FeatureRestored.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Laravel\Pennant\Events;
+
+use Illuminate\Queue\SerializesModels;
+
+class FeatureRestored
+{
+    use SerializesModels;
+
+    /**
+     * The feature name.
+     *
+     * @var string
+     */
+    public $feature;
+
+    /**
+     * The scope of the feature restore.
+     *
+     * @var mixed
+     */
+    public $scope;
+
+    /**
+     * The feature's fallback value.
+     *
+     * @var mixed
+     */
+    public $fallback;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param  string  $feature
+     * @param  mixed  $scope
+     * @param  mixed  $fallback
+     */
+    public function __construct($feature, $scope, $fallback)
+    {
+        $this->feature = $feature;
+        $this->scope = $scope;
+        $this->fallback = $fallback;
+    }
+}

--- a/src/Events/FeatureRestoredForAllScopes.php
+++ b/src/Events/FeatureRestoredForAllScopes.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Laravel\Pennant\Events;
+
+use Illuminate\Queue\SerializesModels;
+
+class FeatureRestoredForAllScopes
+{
+    use SerializesModels;
+
+    /**
+     * The feature name.
+     *
+     * @var string
+     */
+    public $feature;
+
+    /**
+     * The feature's fallback value.
+     *
+     * @var mixed
+     */
+    public $fallback;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param  string  $feature
+     * @param  mixed  $value
+     */
+    public function __construct($feature, $fallback)
+    {
+        $this->feature = $feature;
+        $this->fallback = $fallback;
+    }
+}

--- a/src/Events/FeatureRestoredForAllScopes.php
+++ b/src/Events/FeatureRestoredForAllScopes.php
@@ -26,7 +26,7 @@ class FeatureRestoredForAllScopes
      * Create a new event instance.
      *
      * @param  string  $feature
-     * @param  mixed  $value
+     * @param  mixed  $fallback
      */
     public function __construct($feature, $fallback)
     {

--- a/src/Feature.php
+++ b/src/Feature.php
@@ -25,6 +25,7 @@ use Illuminate\Support\Facades\Facade;
  * @method static array defined()
  * @method static array stored()
  * @method static void activateForEveryone(string|array $feature, mixed $value = true)
+ * @method static void restoreForEveryone(string|array $feature, mixed $fallback = true)
  * @method static void deactivateForEveryone(string|array $feature)
  * @method static void purge(string|array|null $features = null)
  * @method static string name(string $feature)
@@ -51,6 +52,7 @@ use Illuminate\Support\Facades\Facade;
  * @method static mixed when(string $feature, \Closure $whenActive, \Closure|null $whenInactive = null)
  * @method static mixed unless(string $feature, \Closure $whenInactive, \Closure|null $whenActive = null)
  * @method static void activate(string|array $feature, mixed $value = true)
+ * @method static void restore(string|array $feature, mixed $fallback = true)
  * @method static void deactivate(string|array $feature)
  * @method static void forget(string|array $features)
  *

--- a/src/PendingScopedFeatureInteraction.php
+++ b/src/PendingScopedFeatureInteraction.php
@@ -258,7 +258,7 @@ class PendingScopedFeatureInteraction
      * Restore the feature.
      *
      * @param  string|array<string>  $feature
-     * @param  mixed  $value
+     * @param  mixed  $fallback
      * @return void
      */
     public function restore($feature, $fallback = true)

--- a/src/PendingScopedFeatureInteraction.php
+++ b/src/PendingScopedFeatureInteraction.php
@@ -255,6 +255,20 @@ class PendingScopedFeatureInteraction
     }
 
     /**
+     * Restore the feature.
+     *
+     * @param  string|array<string>  $feature
+     * @param  mixed  $value
+     * @return void
+     */
+    public function restore($feature, $fallback = true)
+    {
+        Collection::wrap($feature)
+            ->crossJoin($this->scope())
+            ->each(fn ($bits) => $this->driver->restore($bits[0], $bits[1], $fallback));
+    }
+
+    /**
      * Deactivate the feature.
      *
      * @param  string|array<string>  $feature

--- a/tests/Feature/DatabaseDriverTest.php
+++ b/tests/Feature/DatabaseDriverTest.php
@@ -19,6 +19,8 @@ use Laravel\Pennant\Events\AllFeaturesPurged;
 use Laravel\Pennant\Events\DynamicallyRegisteringFeatureClass;
 use Laravel\Pennant\Events\FeatureDeleted;
 use Laravel\Pennant\Events\FeatureResolved;
+use Laravel\Pennant\Events\FeatureRestored;
+use Laravel\Pennant\Events\FeatureRestoredForAllScopes;
 use Laravel\Pennant\Events\FeaturesPurged;
 use Laravel\Pennant\Events\FeatureUpdated;
 use Laravel\Pennant\Events\FeatureUpdatedForAllScopes;
@@ -53,6 +55,106 @@ class DatabaseDriverTest extends TestCase
         $this->assertFalse($result);
 
         $this->assertCount(1, DB::getQueryLog());
+    }
+
+    public function test_it_can_restore_a_rich_feature_value_with_a_fallback()
+    {
+        Feature::define('foo', fn () => false);
+
+        $this->assertFalse(Feature::for('tim')->value('foo'));
+        $this->assertFalse(Feature::for('tim')->active('foo'));
+        $this->assertFalse(Feature::getDriver()->get('foo', 'tim'));
+
+        Feature::for('tim')->restore('foo', fallback: 'bar');
+
+        $this->assertSame('bar', Feature::for('tim')->value('foo'));
+        $this->assertTrue(Feature::for('tim')->active('foo'));
+        $this->assertSame('bar', Feature::getDriver()->get('foo', 'tim'));
+    }
+
+    public function test_it_can_restore_a_rich_feature_value()
+    {
+        Feature::define('foo', fn () => false);
+
+        Feature::for('tim')->activate('foo', 'bar');
+
+        $this->assertSame('bar', Feature::for('tim')->value('foo'));
+        $this->assertTrue(Feature::for('tim')->active('foo'));
+        $this->assertSame('bar', Feature::getDriver()->get('foo', 'tim'));
+
+        Feature::for('tim')->deactivate('foo');
+
+        $this->assertFalse(Feature::for('tim')->value('foo'));
+        $this->assertFalse(Feature::for('tim')->active('foo'));
+        $this->assertFalse(Feature::getDriver()->get('foo', 'tim'));
+
+        Feature::for('tim')->restore('foo');
+
+        $this->assertSame('bar', Feature::for('tim')->value('foo'));
+        $this->assertTrue(Feature::for('tim')->active('foo'));
+        $this->assertSame('bar', Feature::getDriver()->get('foo', 'tim'));
+    }
+
+    public function test_it_can_restore_a_rich_feature_value_for_everyone()
+    {
+        Feature::define('foo', fn () => false);
+
+        Feature::for('tim')->activate('foo', 'bar');
+        Feature::for('taylor')->activate('foo', 'bar');
+
+        $this->assertSame('bar', Feature::for('tim')->value('foo'));
+        $this->assertSame('bar', Feature::for('taylor')->value('foo'));
+        $this->assertSame('bar', Feature::getDriver()->get('foo', 'tim'));
+        $this->assertSame('bar',Feature::getDriver()->get('foo', 'taylor'));
+
+        Feature::deactivateForEveryone('foo');
+
+        $this->assertFalse(Feature::for('tim')->value('foo'));
+        $this->assertFalse(Feature::for('taylor')->value('foo'));
+        $this->assertFalse(Feature::getDriver()->get('foo', 'tim'));
+        $this->assertFalse(Feature::getDriver()->get('foo', 'taylor'));
+
+        Feature::restoreForEveryone('foo');
+
+        $this->assertSame('bar', Feature::for('tim')->value('foo'));
+        $this->assertSame('bar', Feature::for('taylor')->value('foo'));
+        $this->assertSame('bar', Feature::getDriver()->get('foo', 'tim'));
+        $this->assertSame('bar', Feature::getDriver()->get('foo', 'taylor'));
+    }
+
+    public function test_it_dispatches_events_on_restore()
+    {
+        Event::fake([FeatureRestored::class]);
+
+        Feature::define('foo', fn () => false);
+
+        Feature::for('tim')->restore('foo');
+
+        Event::assertDispatchedTimes(FeatureRestored::class, 1);
+        Event::assertDispatched(function (FeatureRestored $event) {
+            $this->assertSame('foo', $event->feature);
+            $this->assertSame('tim', $event->scope);
+            $this->assertTrue($event->fallback);
+
+            return true;
+        });
+    }
+
+    public function test_it_dispatches_events_on_restore_for_everyone()
+    {
+        Event::fake([FeatureRestoredForAllScopes::class]);
+
+        Feature::define('foo', fn () => false);
+
+        Feature::restoreForEveryone('foo');
+
+        Event::assertDispatchedTimes(FeatureRestoredForAllScopes::class, 1);
+        Event::assertDispatched(function (FeatureRestoredForAllScopes $event) {
+            $this->assertSame('foo', $event->feature);
+            $this->assertTrue($event->fallback);
+
+            return true;
+        });
     }
 
     public function test_it_dispatches_events_on_unknown_feature_checks()


### PR DESCRIPTION
As discussed with @timacdonald in #133 this adds a boolean column for the database driver to allow marking a feature flag inactive without erasing its previous value. This means that after a temporary rollback of a feature, a user's value for that feature can be restored upon reactivation, using the following new api:

```php
Feature::activate('custom-font', 'Agu Display');

Feature::deactivate('custom-font'); // remembers 'Agu Display'

Feature::restore('custom-font', fallback: 'Arial'); // will restore to 'Agu Display'
```

This PR also allows restoring features for all scopes, in the same manner as `Feature::restoreForEveryone()`

```php
Feature::activateForEveryone('custom-background', 'default-background');

Feature::for('robin')->activate('custom-background', 'sunny-afternoon');

Feature::deactivateForEveryone('custom-background');

Feature::restoreForEveryone('custom-background', fallback: 'default-background');

Feature::for('robin')->value('custom-background'); // sunny-afternoon
```

Includes tests, and events `FeatureRestored` and `FeatureRestoredForAllScopes` which are fired upon `Feature::restore` and `Feature::restoreForEveryone`, respectively.

Major changes:

- The major change in behavior here is that deactivating a feature will no longer change its value; it will simply mark it inactive. However this is done transparently and the same value as before is returned for inactive features (`false`).
- Also notable is that this adds two methods to a public interface. Maintainers of custom drivers will need to implement those methods in order to upgrade.
- This will require running a migration. The column is nullable and isset checks are used for a smooth upgrade; however there are no checks for the column's existence. Let me know if you want me to wrap those (queries) in a flag, to allow user code to continue run as is after upgrade but prior to running the migration.
- After upgrading and running the migration, existing usage of the original API will continue to function as is, without any code changes.