### PR TITLE
Show a default error message when the middleware check fails

### DIFF
--- a/src/Middleware/EnsureFeaturesAreActive.php
+++ b/src/Middleware/EnsureFeaturesAreActive.php
@@ -20,7 +20,7 @@ class EnsureFeaturesAreActive
         if (Feature::someAreInactive($features)) {
             return static::$respondUsing
                 ? call_user_func(static::$respondUsing, $request, $features)
-                : abort(400);
+                : abort(400, 'Features ['.join(', ', $features).'] not enabled.');
         }
 
         return $next($request);

--- a/src/Middleware/EnsureFeaturesAreActive.php
+++ b/src/Middleware/EnsureFeaturesAreActive.php
@@ -18,9 +18,13 @@ class EnsureFeaturesAreActive
         Feature::loadMissing($features);
 
         if (Feature::someAreInactive($features)) {
+            $error = config('app.debug')
+                ? 'Required features ['.join(', ', $features).'] not enabled.'
+                : 'Required features not enabled.';
+
             return static::$respondUsing
                 ? call_user_func(static::$respondUsing, $request, $features)
-                : abort(400, 'Features ['.join(', ', $features).'] not enabled.');
+                : abort(400, $error);
         }
 
         return $next($request);

--- a/src/Middleware/EnsureFeaturesAreActive.php
+++ b/src/Middleware/EnsureFeaturesAreActive.php
@@ -20,7 +20,7 @@ class EnsureFeaturesAreActive
         if (Feature::someAreInactive($features)) {
             $error = config('app.debug')
                 ? 'Required features ['.join(', ', $features).'] not enabled.'
-                : 'Required features not enabled.';
+                : '';
 
             return static::$respondUsing
                 ? call_user_func(static::$respondUsing, $request, $features)


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
When using the `EnsureFeaturesAreActive` middleware, you may see errors like this, which aren't super helpful.

## Before
<img width="1473" alt="Screenshot 2025-05-29 at 22 02 30" src="https://github.com/user-attachments/assets/58724fa8-bc14-4423-b2a9-f00e08bfc911" />

## After
<img width="1465" alt="Screenshot 2025-05-29 at 22 03 27" src="https://github.com/user-attachments/assets/be9870eb-ad06-49ca-b0f0-fffe6a7f8483" />

I'll add a test for this if desired.