### PR TITLE
Fix - Correct retrieval of `0` feature values via DB driver

### DIFF
--- a/src/Drivers/DatabaseDriver.php
+++ b/src/Drivers/DatabaseDriver.php
@@ -158,7 +158,7 @@ class DatabaseDriver implements CanListStoredFeatures, Driver
             $filtered = $records->where('name', $feature)->where('scope', Feature::serializeScope($scope));
 
             if ($filtered->isNotEmpty()) {
-                return json_decode($filtered->value('value'), flags: JSON_OBJECT_AS_ARRAY | JSON_THROW_ON_ERROR); // @phpstan-ignore argument.type
+                return json_decode($filtered->first()->value, flags: JSON_OBJECT_AS_ARRAY | JSON_THROW_ON_ERROR);
             }
 
             return with($this->resolveValue($feature, $scope), function ($value) use ($feature, $scope, $inserts) {

--- a/tests/Feature/ArrayDriverTest.php
+++ b/tests/Feature/ArrayDriverTest.php
@@ -1178,6 +1178,41 @@ class ArrayDriverTest extends TestCase
         $this->assertInstanceOf(Lottery::class, $feature);
         $this->assertSame('345', $feature());
     }
+
+    public function test_can_retrieve_scalar_values_without_in_memory_cache(): void
+    {
+        $data = [
+            'one' => 1,
+            'ten' => 10,
+            'zero' => 0,
+            'minus-one' => -1,
+            'minus-ten' => -10,
+            'one-point-five' => 1.5,
+            'ten-point-five' => 10.5,
+            'zero-point-five' => 0.5,
+            'minus-one-point-five' => -1.5,
+            'minus-ten-point-five' => -10.5,
+            'bool-true' => true,
+            'bool-false' => false,
+            'null' => null,
+        ];
+
+        $user = new User;
+
+        foreach ($data as $name => $expectedValue) {
+            $feature = 'scalar-feature:'.$name;
+            Feature::define($feature, fn(User $user) => $expectedValue);
+
+            $generated = Feature::for($user)->value($feature);
+
+            Feature::flushCache();
+
+            $retrieved = Feature::for($user)->value($feature);
+
+            $this->assertEquals($expectedValue, $generated);
+            $this->assertEquals($expectedValue, $retrieved);
+        }
+    }
 }
 
 class MyFeature

--- a/tests/Feature/DatabaseDriverTest.php
+++ b/tests/Feature/DatabaseDriverTest.php
@@ -1708,6 +1708,41 @@ class DatabaseDriverTest extends TestCase
         $this->assertCount(8, DB::getQueryLog());
         $this->assertCount(13, DB::table('features')->get());
     }
+
+    public function test_can_retrieve_scalar_values_without_in_memory_cache(): void
+    {
+        $data = [
+            'one' => 1,
+            'ten' => 10,
+            'zero' => 0,
+            'minus-one' => -1,
+            'minus-ten' => -10,
+            'one-point-five' => 1.5,
+            'ten-point-five' => 10.5,
+            'zero-point-five' => 0.5,
+            'minus-one-point-five' => -1.5,
+            'minus-ten-point-five' => -10.5,
+            'bool-true' => true,
+            'bool-false' => false,
+            'null' => null,
+        ];
+
+        $user = new User;
+
+        foreach ($data as $name => $expectedValue) {
+            $feature = 'scalar-feature:'.$name;
+            Feature::define($feature, fn(User $user) => $expectedValue);
+
+            $generated = Feature::for($user)->value($feature);
+
+            Feature::flushCache();
+
+            $retrieved = Feature::for($user)->value($feature);
+
+            $this->assertEquals($expectedValue, $generated);
+            $this->assertEquals($expectedValue, $retrieved);
+        }
+    }
 }
 
 class UnregisteredFeature


### PR DESCRIPTION
Proposed fix for Issue #142 

When a stored value for a feature is `0` (JSON `"0"`), `$filtered->value('value')` internally makes a loose comparison of `"0" == true`, resulting in no matches being found. 

`null` is then passed into `json_decode()`, triggering the following:

```
   DEPRECATED  json_decode(): Passing null to parameter #1 ($json) of type string is deprecated in vendor/laravel/pennant/src/Drivers/DatabaseDriver.php on line 161.


   JsonException  Syntax error.
```

Issue was reproduced with tests pre-solve.

The fix assumes that if `$filtered` has records which match the provided `$feature` and `$scope` it can just grab the value directly from `->first()` - that would typically have one result I believe.