### PR TITLE
Add `nameMap` to decorator

### DIFF
--- a/src/Drivers/Decorator.php
+++ b/src/Drivers/Decorator.php
@@ -592,6 +592,14 @@ class Decorator implements CanListStoredFeatures, Driver, HasFlushableCache
     }
 
     /**
+     * Retrieve the map of feature names to their implementations.
+     */
+    public function nameMap(): array
+    {
+        return $this->nameMap;
+    }
+
+    /**
      * Retrieve the feature's class.
      *
      * @param  string  $name


### PR DESCRIPTION
This PR adds a `nameMap` method to the `Decorator` class to allow you to fetch a list of features and their implementations. This is useful for listing features.