### PR TITLE
Automatically resolve the flag's type if it's a class string

### DIFF
--- a/src/Drivers/Decorator.php
+++ b/src/Drivers/Decorator.php
@@ -602,8 +602,10 @@ class Decorator implements CanListStoredFeatures, Driver, HasFlushableCache
     /**
      * Retrieve the feature's class.
      *
-     * @param  string  $name
-     * @return mixed
+     * @template TFlag
+     *
+     * @param  TFlag|string  $name
+     * @return (TFlag is class-string<TFlag> ? TFlag : mixed)
      */
     public function instance($name)
     {


### PR DESCRIPTION
This PR extends the docblock of the `instance` method to automatically resolve the feature flag's class if it's a class string.