### PR TITLE
Fix `Feature` docblock annotations

### DIFF
--- a/src/Feature.php
+++ b/src/Feature.php
@@ -29,7 +29,7 @@ use Illuminate\Support\Facades\Facade;
  * @method static void purge(string|array|null $features = null)
  * @method static string name(string $feature)
  * @method static array nameMap()
- * @method static void instance(void $name)
+ * @method static mixed instance(string $name)
  * @method static \Laravel\Pennant\Contracts\Driver getDriver()
  * @method static void macro(string $name, object|callable $macro)
  * @method static void mixin(object $mixin, bool $replace = true)


### PR DESCRIPTION
The feature facade's docblock annotation for the method `instance` does not match the `Decorator` method's docblock anymore. I don't think it's possible to use expressions like `(TFlag is class-string<TFlag> ? TFlag : mixed)` with static methods, therefore I decided to roll it back to what it was previously.