### PR TITLE
Supports before hooks for closure-based features.

### DIFF
--- a/src/Drivers/Decorator.php
+++ b/src/Drivers/Decorator.php
@@ -79,6 +79,13 @@ class Decorator implements CanListStoredFeatures, Driver, HasFlushableCache
     protected $cache;
 
     /**
+     * The registered before hooks.
+     *
+     * @var array<string, callable(mixed):mixed>
+     */
+    protected $beforeHooks = [];
+
+    /**
      * Map of feature names to their implementations.
      *
      * @var array<string, mixed>
@@ -101,6 +108,17 @@ class Decorator implements CanListStoredFeatures, Driver, HasFlushableCache
         $this->defaultScopeResolver = $defaultScopeResolver;
         $this->container = $container;
         $this->cache = $cache;
+    }
+
+    /**
+     * Register a feature's before hook.
+     *
+     * @param  string|class-string  $feature
+     * @param  callable  $hook
+     */
+    public function before($feature, $hook): void
+    {
+        $this->beforeHooks[$feature] = $hook;
     }
 
     /**
@@ -431,9 +449,11 @@ class Decorator implements CanListStoredFeatures, Driver, HasFlushableCache
             return $item['value'];
         }
 
-        $before = $this->hasBeforeHook($feature)
-            ? $this->container->make($this->implementationClass($feature))->before(...)
-            : fn () => null;
+        $before = match (true) {
+            isset($this->beforeHooks[$feature]) => $this->beforeHooks[$feature],
+            $this->hasBeforeHook($feature) => $this->container->make($this->implementationClass($feature))->before(...),
+            default => fn () => null,
+        };
 
         $value = $this->resolveBeforeHook($feature, $scope, $before) ?? $this->driver->get($feature, $scope);
 

--- a/src/Feature.php
+++ b/src/Feature.php
@@ -19,6 +19,7 @@ use Illuminate\Support\Facades\Facade;
  * @method static \Laravel\Pennant\FeatureManager forgetDrivers()
  * @method static \Laravel\Pennant\FeatureManager extend(string $driver, \Closure $callback)
  * @method static \Laravel\Pennant\FeatureManager setContainer(\Illuminate\Container\Container $container)
+ * @method static void before(string $feature, callable $hook)
  * @method static void discover(string $namespace = 'App\\Features', string|null $path = null)
  * @method static void define(string $feature, mixed $resolver = null)
  * @method static bool isResolverValidForScope(callable|string $resolver, mixed $scope)

--- a/tests/Feature/DatabaseDriverTest.php
+++ b/tests/Feature/DatabaseDriverTest.php
@@ -1496,6 +1496,23 @@ class DatabaseDriverTest extends TestCase
         $this->assertSame(0, $queries);
     }
 
+    public function test_it_can_get_features_with_registered_before_hook_callback()
+    {
+        $queries = 0;
+        DB::listen(function (QueryExecuted $event) use (&$queries) {
+            $queries++;
+        });
+
+        Feature::define('feature-with-registered-before-hook-callback', fn ($scope) => 'feature-value');
+
+        Feature::before('feature-with-registered-before-hook-callback', fn ($scope) => ['before' => 'value']);
+
+        $value = Feature::get('feature-with-registered-before-hook-callback', null);
+
+        $this->assertSame(['before' => 'value'], $value);
+        $this->assertSame(0, $queries);
+    }
+
     public function test_it_handles_null_scope_for_before_hook()
     {
         Event::fake(UnexpectedNullScopeEncountered::class);


### PR DESCRIPTION
## Usage

```php

Feature::before('new-api', function (User $user) {
  if (Config::get('features.new-api.disabled')) {
      return $user->isInternalTeamMember();
  }
});
```
