### PR TITLE
Fix type checking bug in `Decorator::typeAllowsScope()` causes primitive type hints to fail scope validation

### DIFF
--- a/src/Drivers/Decorator.php
+++ b/src/Drivers/Decorator.php
@@ -248,20 +248,22 @@ class Decorator implements CanListStoredFeatures, Driver, HasFlushableCache
         }
 
         if ($type instanceof ReflectionNamedType) {
-            if ($type->getName() === 'mixed') {
+            $typeName = $type->getName();
+            
+            if ($typeName === 'mixed') {
                 return true;
             }
 
             return match (gettype($scope)) {
-                'boolean',
-                'integer',
+                'boolean' => in_array($typeName, ['boolean', 'bool']),
+                'integer' => in_array($typeName, ['integer', 'int']),
                 'double',
                 'string',
                 'array',
                 'resource',
-                'resource (closed)' => gettype($scope) === $type->getName(),
+                'resource (closed)' => gettype($scope) === $typeName,
                 'NULL' => $this->canHandleNullScope($function),
-                'object' => $scope instanceof ($type->getName()),
+                'object' => $scope instanceof ($typeName),
                 'unknown type' => false,
             };
         }

--- a/src/Drivers/Decorator.php
+++ b/src/Drivers/Decorator.php
@@ -249,7 +249,7 @@ class Decorator implements CanListStoredFeatures, Driver, HasFlushableCache
 
         if ($type instanceof ReflectionNamedType) {
             $typeName = $type->getName();
-            
+
             if ($typeName === 'mixed') {
                 return true;
             }

--- a/src/Drivers/Decorator.php
+++ b/src/Drivers/Decorator.php
@@ -257,7 +257,7 @@ class Decorator implements CanListStoredFeatures, Driver, HasFlushableCache
             return match (gettype($scope)) {
                 'boolean' => in_array($typeName, ['boolean', 'bool']),
                 'integer' => in_array($typeName, ['integer', 'int']),
-                'double',
+                'double' => in_array($typeName, ['double', 'float']),
                 'string',
                 'array',
                 'resource',

--- a/tests/Feature/ArrayDriverTest.php
+++ b/tests/Feature/ArrayDriverTest.php
@@ -1219,12 +1219,54 @@ class ArrayDriverTest extends TestCase
         Feature::define(IntScopeFeature::class);
 
         $this->assertSame([
-            'Tests\Feature\IntScopeFeature' => true,
+            IntScopeFeature::class => true,
         ], Feature::for(1)->all());
 
         $this->assertSame([
-            'Tests\Feature\IntScopeFeature' => false,
+            IntScopeFeature::class => false,
         ], Feature::for(10)->all());
+    }
+
+    public function test_it_can_handles_double_scopes_correctly()
+    {
+        Feature::define(DoubleScopeFeature::class);
+
+        $this->assertSame([
+            DoubleScopeFeature::class => true,
+        ], Feature::for(1.1)->all());
+
+        $this->assertSame([
+            DoubleScopeFeature::class => true,
+        ], Feature::for(1.10)->all());
+
+        $this->assertSame([
+            DoubleScopeFeature::class => false,
+        ], Feature::for(1.11)->all());
+
+        $this->assertSame([
+            DoubleScopeFeature::class => false,
+        ], Feature::for(10.00)->all());
+    }
+
+    public function test_it_can_handles_float_scopes_correctly()
+    {
+        Feature::define(FloatScopeFeature::class);
+
+        $this->assertSame([
+            FloatScopeFeature::class => true,
+        ], Feature::for(1.1)->all());
+
+        $this->assertSame([
+            FloatScopeFeature::class => true,
+        ], Feature::for(1.10)->all());
+
+        $this->assertSame([
+            FloatScopeFeature::class => false,
+        ], Feature::for(1.11)->all());
+
+        $this->assertSame([
+            FloatScopeFeature::class => false,
+        ], Feature::for(10.00)->all());
     }
 }
 
@@ -1317,5 +1359,21 @@ class IntScopeFeature
     public function resolve(int $scope): bool
     {
         return in_array($scope, [1, 2, 3], true);
+    }
+}
+
+class DoubleScopeFeature
+{
+    public function resolve(float $scope): bool
+    {
+        return in_array($scope, [1.10, 2.20, 3.30], true);
+    }
+}
+
+class FloatScopeFeature
+{
+    public function resolve(float $scope): bool
+    {
+        return in_array($scope, [1.1, 2.2, 3.3], true);
     }
 }

--- a/tests/Feature/ArrayDriverTest.php
+++ b/tests/Feature/ArrayDriverTest.php
@@ -1319,4 +1319,3 @@ class IntScopeFeature
         return in_array($scope, [1, 2, 3], true);
     }
 }
-

--- a/tests/Feature/ArrayDriverTest.php
+++ b/tests/Feature/ArrayDriverTest.php
@@ -1213,6 +1213,19 @@ class ArrayDriverTest extends TestCase
             $this->assertEquals($expectedValue, $retrieved);
         }
     }
+
+    public function test_it_handles_integer_scopes_correctly()
+    {
+        Feature::define(IntScopeFeature::class);
+
+        $this->assertSame([
+            'Tests\Feature\IntScopeFeature' => true,
+        ], Feature::for(1)->all());
+
+        $this->assertSame([
+            'Tests\Feature\IntScopeFeature' => false,
+        ], Feature::for(10)->all());
+    }
 }
 
 class MyFeature
@@ -1298,3 +1311,12 @@ class FeatureDependency
 {
     //
 }
+
+class IntScopeFeature
+{
+    public function resolve(int $scope): bool
+    {
+        return in_array($scope, [1, 2, 3], true);
+    }
+}
+


### PR DESCRIPTION
fix #152

* [x] integer
* [x] boolean
* [x] double/float

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
