### PR TITLE
[1.x] Adjust `Decorator::__call` to use `defaultScope()` method and only call once

### DIFF
--- a/src/Drivers/Decorator.php
+++ b/src/Drivers/Decorator.php
@@ -854,8 +854,8 @@ class Decorator implements CanListStoredFeatures, Driver, HasFlushableCache
         }
 
         return tap(new PendingScopedFeatureInteraction($this), function ($interaction) use ($name) {
-            if ($name !== 'for' && ($this->defaultScopeResolver)() !== null) {
-                $interaction->for(($this->defaultScopeResolver)());
+            if ($name !== 'for' && ($scope = $this->defaultScope()) !== null) {
+                $interaction->for($scope);
             }
         })->{$name}(...$parameters);
     }


### PR DESCRIPTION
This PR improves performance of the default scope resolution logic in the `__call` method of the `Decorator` class by assigning the result of `defaultScope()` to a variable so the `defaultScope()` method isn't called twice unnecessarily.