### PR TITLE
feat!: add `setAll` method to driver

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /composer.lock
 /phpunit.xml
 /.phpunit.cache
+.idea

--- a/src/Contracts/Driver.php
+++ b/src/Contracts/Driver.php
@@ -37,6 +37,13 @@ interface Driver
     public function set(string $feature, mixed $scope, mixed $value): void;
 
     /**
+     * Set multiple feature flag values.
+     *
+     * @param  array<int, array<string, string>>  $features
+     */
+    public function setAll(array $features): void;
+
+    /**
      * Set a feature flag's value for all scopes.
      */
     public function setForAllScopes(string $feature, mixed $value): void;

--- a/src/Drivers/ArrayDriver.php
+++ b/src/Drivers/ArrayDriver.php
@@ -159,6 +159,18 @@ class ArrayDriver implements CanListStoredFeatures, Driver, HasFlushableCache
     }
 
     /**
+     * Set multiple feature flag values.
+     *
+     * @param  array<int, array<string, mixed>>  $features
+     */
+    public function setAll($features): void
+    {
+        foreach ($features as $featureData) {
+            $this->set($featureData['feature'], $featureData['scope'], $featureData['value']);
+        }
+    }
+
+    /**
      * Set a feature flag's value for all scopes.
      *
      * @param  string  $feature

--- a/src/Drivers/DatabaseDriver.php
+++ b/src/Drivers/DatabaseDriver.php
@@ -282,6 +282,32 @@ class DatabaseDriver implements CanListStoredFeatures, Driver
     }
 
     /**
+     * Set multiple feature flag values.
+     *
+     * @param  array<int, array<string, mixed>>  $features
+     */
+    public function setAll(array $features): void
+    {
+        $now = Carbon::now();
+
+        $this->newQuery()->upsert([
+            array_map(
+                static fn (array $feature) => array_merge(
+                    $feature,
+                    [
+                        'name' => $feature,
+                        'scope' => Feature::serializeScope($feature['scope']),
+                        'value' => json_encode($feature['value'], flags: JSON_THROW_ON_ERROR),
+                        static::CREATED_AT => $now,
+                        static::UPDATED_AT => $now,
+                    ]
+                ),
+                $features
+            )
+        ], uniqueBy: ['name', 'scope'], update: ['value', static::UPDATED_AT]);
+    }
+
+    /**
      * Set a feature flag's value for all scopes.
      *
      * @param  string  $feature

--- a/src/Drivers/Decorator.php
+++ b/src/Drivers/Decorator.php
@@ -488,6 +488,34 @@ class Decorator implements CanListStoredFeatures, Driver, HasFlushableCache
     }
 
     /**
+     * Set multiple feature flag values.
+     *
+     * @internal
+     *
+     * @param  array<int, array<string, mixed>>  $features
+     */
+    public function setAll(array $features): void
+    {
+        $features = array_map(fn ($feature) => [
+            'feature' => $this->resolveFeature($feature['feature']),
+            'scope' => $this->resolveScope($feature['scope']),
+            'value' => $feature['value'],
+        ], $features);
+
+        $this->driver->setAll($features);
+
+        foreach ($features as $featureData) {
+            $this->putInCache($featureData['feature'], $featureData['scope'], $featureData['value']);
+
+            Event::dispatch(new FeatureUpdated(
+                $featureData['feature'],
+                $featureData['scope'],
+                $featureData['value'],
+            ));
+        }
+    }
+
+    /**
      * Activate the feature for everyone.
      *
      * @param  string|array<string>  $feature

--- a/src/PendingScopedFeatureInteraction.php
+++ b/src/PendingScopedFeatureInteraction.php
@@ -249,9 +249,12 @@ class PendingScopedFeatureInteraction
      */
     public function activate($feature, $value = true)
     {
-        Collection::wrap($feature)
+        $features = Collection::wrap($feature)
             ->crossJoin($this->scope())
-            ->each(fn ($bits) => $this->driver->set($bits[0], $bits[1], $value));
+            ->map(fn ($bits) => ['feature' => $bits[0], 'scope' => $bits[1], 'value' => $value])
+            ->all();
+
+        $this->driver->setAll($features);
     }
 
     /**
@@ -262,9 +265,12 @@ class PendingScopedFeatureInteraction
      */
     public function deactivate($feature)
     {
-        Collection::wrap($feature)
+        $features = Collection::wrap($feature)
             ->crossJoin($this->scope())
-            ->each(fn ($bits) => $this->driver->set($bits[0], $bits[1], false));
+            ->map(fn ($bits) => ['feature' => $bits[0], 'scope' => $bits[1], 'value' => false])
+            ->all();
+
+        $this->driver->setAll($features);
     }
 
     /**

--- a/tests/Feature/ArrayDriverTest.php
+++ b/tests/Feature/ArrayDriverTest.php
@@ -1268,6 +1268,96 @@ class ArrayDriverTest extends TestCase
             FloatScopeFeature::class => false,
         ], Feature::for(10.00)->all());
     }
+
+    public function test_it_dispatches_events_when_activating_multiple_features_and_scopes()
+    {
+        Event::fake([FeatureUpdated::class]);
+
+        $first = new User(['id' => 1]);
+        $second = new User(['id' => 2]);
+
+        Feature::for([$first, $second])->activate(['foo', 'bar']);
+
+        Event::assertDispatchedTimes(FeatureUpdated::class, 4);
+
+        $events = [];
+        Event::assertDispatched(function (FeatureUpdated $event) use (&$events) {
+            $events[] = [
+                'feature' => $event->feature,
+                'scope' => $event->scope,
+                'value' => $event->value,
+            ];
+
+            return true;
+        });
+
+        $this->assertCount(4, $events);
+        $this->assertContains([
+            'feature' => 'foo',
+            'scope' => $first,
+            'value' => true,
+        ], $events);
+        $this->assertContains([
+            'feature' => 'foo',
+            'scope' => $second,
+            'value' => true,
+        ], $events);
+        $this->assertContains([
+            'feature' => 'bar',
+            'scope' => $first,
+            'value' => true,
+        ], $events);
+        $this->assertContains([
+            'feature' => 'bar',
+            'scope' => $second,
+            'value' => true,
+        ], $events);
+    }
+
+    public function test_it_dispatches_events_when_deactivating_multiple_features_and_scopes()
+    {
+        Event::fake([FeatureUpdated::class]);
+
+        $first = new User(['id' => 1]);
+        $second = new User(['id' => 2]);
+
+        Feature::for([$first, $second])->deactivate(['foo', 'bar']);
+
+        Event::assertDispatchedTimes(FeatureUpdated::class, 4);
+
+        $events = [];
+        Event::assertDispatched(function (FeatureUpdated $event) use (&$events) {
+            $events[] = [
+                'feature' => $event->feature,
+                'scope' => $event->scope,
+                'value' => $event->value,
+            ];
+
+            return true;
+        });
+
+        $this->assertCount(4, $events);
+        $this->assertContains([
+            'feature' => 'foo',
+            'scope' => $first,
+            'value' => false,
+        ], $events);
+        $this->assertContains([
+            'feature' => 'foo',
+            'scope' => $second,
+            'value' => false,
+        ], $events);
+        $this->assertContains([
+            'feature' => 'bar',
+            'scope' => $first,
+            'value' => false,
+        ], $events);
+        $this->assertContains([
+            'feature' => 'bar',
+            'scope' => $second,
+            'value' => false,
+        ], $events);
+    }
 }
 
 class MyFeature

--- a/tests/Feature/DatabaseDriverTest.php
+++ b/tests/Feature/DatabaseDriverTest.php
@@ -1743,6 +1743,108 @@ class DatabaseDriverTest extends TestCase
             $this->assertEquals($expectedValue, $retrieved);
         }
     }
+
+    public function test_it_dispatches_events_when_activating_multiple_features_and_scopes()
+    {
+        Event::fake([FeatureUpdated::class]);
+
+        $first = new User(['id' => 1]);
+        $second = new User(['id' => 2]);
+
+        Feature::for([$first, $second])->activate(['foo', 'bar']);
+
+        Event::assertDispatchedTimes(FeatureUpdated::class, 4);
+
+        $events = [];
+        Event::assertDispatched(function (FeatureUpdated $event) use (&$events) {
+            $events[] = [
+                'feature' => $event->feature,
+                'scope' => $event->scope,
+                'value' => $event->value,
+            ];
+
+            return true;
+        });
+
+        $this->assertCount(4, $events);
+        $this->assertContains([
+            'feature' => 'foo',
+            'scope' => $first,
+            'value' => true,
+        ], $events);
+        $this->assertContains([
+            'feature' => 'foo',
+            'scope' => $second,
+            'value' => true,
+        ], $events);
+        $this->assertContains([
+            'feature' => 'bar',
+            'scope' => $first,
+            'value' => true,
+        ], $events);
+        $this->assertContains([
+            'feature' => 'bar',
+            'scope' => $second,
+            'value' => true,
+        ], $events);
+    }
+
+    public function test_it_dispatches_events_when_deactivating_multiple_features_and_scopes()
+    {
+        Event::fake([FeatureUpdated::class]);
+
+        $first = new User(['id' => 1]);
+        $second = new User(['id' => 2]);
+
+        Feature::for([$first, $second])->deactivate(['foo', 'bar']);
+
+        Event::assertDispatchedTimes(FeatureUpdated::class, 4);
+
+        $events = [];
+        Event::assertDispatched(function (FeatureUpdated $event) use (&$events) {
+            $events[] = [
+                'feature' => $event->feature,
+                'scope' => $event->scope,
+                'value' => $event->value,
+            ];
+
+            return true;
+        });
+
+        $this->assertCount(4, $events);
+        $this->assertContains([
+            'feature' => 'foo',
+            'scope' => $first,
+            'value' => false,
+        ], $events);
+        $this->assertContains([
+            'feature' => 'foo',
+            'scope' => $second,
+            'value' => false,
+        ], $events);
+        $this->assertContains([
+            'feature' => 'bar',
+            'scope' => $first,
+            'value' => false,
+        ], $events);
+        $this->assertContains([
+            'feature' => 'bar',
+            'scope' => $second,
+            'value' => false,
+        ], $events);
+    }
+
+    public function test_it_uses_single_query_when_activating_multiple_features_and_scopes()
+    {
+        DB::enableQueryLog();
+
+        $first = new User(['id' => 1]);
+        $second = new User(['id' => 2]);
+
+        Feature::for([$first, $second])->activate(['foo', 'bar']);
+
+        $this->assertCount(1, DB::getQueryLog());
+    }
 }
 
 class UnregisteredFeature


### PR DESCRIPTION
It would be nice if the ->activate() didn't create multiple queries when it can be one.
This is a breaking change due to interface changing breaking somebody's implementation.
I could not test it as I was getting:
```
Illuminate\Database\QueryException: could not find driver (Connection: testing, SQL: select exists (select 1 from "main".sqlite_master where name = 'migrations' and type = 'table') as "exists")
```
So I'm just pushing it up to see what happens in CI. Also good to get some feedback early.