### PR TITLE
feat(commands): add toggle command with force on/off support

### DIFF
--- a/src/Commands/ToggleCommand.php
+++ b/src/Commands/ToggleCommand.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Laravel\Pennant\Commands;
+
+use Illuminate\Console\Command;
+use Laravel\Pennant\FeatureManager;
+use Symfony\Component\Console\Attribute\AsCommand;
+
+#[AsCommand(name: 'pennant:toggle')]
+class ToggleCommand extends Command
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $signature = 'pennant:toggle
+                            {feature : The feature to toggle}
+                            {--scope= : The optional scope identifier (e.g. user:123, team:abc)}
+                            {--on : Force activation (instead of toggling)}
+                            {--off : Force deactivation (instead of toggling)}
+                            {--store= : The store to toggle the feature in}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Toggle a feature flag on/off globally or for a specific scope';
+
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     */
+    public function handle(FeatureManager $manager)
+    {
+        $feature = $this->argument('feature');
+        $scopeInput = $this->option('scope');
+        $forceOn = $this->option('on');
+        $forceOff = $this->option('off');
+        $store = $manager->store($this->option('store'));
+
+        $scope = $scopeInput !== null ? $scopeInput : null;
+
+        $currentValue = $scope !== null
+            ? $store->for($scope)->value($feature)
+            : $store->value($feature);
+
+        $isCurrentlyActive = $currentValue === true || $currentValue !== false && $currentValue !== null;
+
+        if ($forceOn) {
+            $newValue = true;
+            $action = 'activated';
+        } elseif ($forceOff) {
+            $newValue = false;
+            $action = 'deactivated';
+        } else {
+            $newValue = ! $isCurrentlyActive;
+            $action = $newValue ? 'activated' : 'deactivated';
+        }
+
+        if ($scope !== null) {
+            if ($newValue) {
+                $store->for($scope)->activate($feature, $newValue);
+            } else {
+                $store->for($scope)->deactivate($feature);
+            }
+            $scopeMsg = " for scope '{$scope}'";
+        } else {
+            if ($newValue) {
+                $store->activate($feature, $newValue);
+            } else {
+                $store->deactivate($feature);
+            }
+            $scopeMsg = ' globally';
+        }
+
+        $this->components->info("Feature '{$feature}' {$action}{$scopeMsg}.");
+
+        $this->line("  Before: " . ($isCurrentlyActive ? '<fg=green>active</>' : '<fg=red>inactive</>'));
+        $this->line("   After: " . ($newValue ? '<fg=green>active</>' : '<fg=red>inactive</>'));
+
+        return self::SUCCESS;
+    }
+}

--- a/src/Commands/ToggleCommand.php
+++ b/src/Commands/ToggleCommand.php
@@ -16,7 +16,7 @@ class ToggleCommand extends Command
      */
     protected $signature = 'pennant:toggle
                             {feature : The feature to toggle}
-                            {--scope= : The optional scope identifier (e.g. user:123, team:abc)}
+                            {--scope= : The optional scope identifier}
                             {--on : Force activation (instead of toggling)}
                             {--off : Force deactivation (instead of toggling)}
                             {--store= : The store to toggle the feature in}';
@@ -36,18 +36,16 @@ class ToggleCommand extends Command
     public function handle(FeatureManager $manager)
     {
         $feature = $this->argument('feature');
-        $scopeInput = $this->option('scope');
+        $scope = $this->option('scope') ?: null;
         $forceOn = $this->option('on');
         $forceOff = $this->option('off');
         $store = $manager->store($this->option('store'));
 
-        $scope = $scopeInput !== null ? $scopeInput : null;
-
-        $currentValue = $scope !== null
+        $currentValue = $scope
             ? $store->for($scope)->value($feature)
             : $store->value($feature);
 
-        $isCurrentlyActive = $currentValue === true || $currentValue !== false && $currentValue !== null;
+        $isCurrentlyActive = $currentValue === true || ($currentValue !== false && $currentValue !== null);
 
         if ($forceOn) {
             $newValue = true;
@@ -60,26 +58,23 @@ class ToggleCommand extends Command
             $action = $newValue ? 'activated' : 'deactivated';
         }
 
-        if ($scope !== null) {
-            if ($newValue) {
-                $store->for($scope)->activate($feature, $newValue);
-            } else {
-                $store->for($scope)->deactivate($feature);
-            }
-            $scopeMsg = " for scope '{$scope}'";
+        $target = $scope ? $store->for($scope) : $store;
+
+        if ($newValue) {
+            $target->activate($feature, $newValue);
         } else {
-            if ($newValue) {
-                $store->activate($feature, $newValue);
-            } else {
-                $store->deactivate($feature);
-            }
-            $scopeMsg = ' globally';
+            $target->deactivate($feature);
         }
 
-        $this->components->info("Feature '{$feature}' {$action}{$scopeMsg}.");
+        $scopePart = $scope ? " for scope '{$scope}'" : ' globally';
 
-        $this->line("  Before: " . ($isCurrentlyActive ? '<fg=green>active</>' : '<fg=red>inactive</>'));
-        $this->line("   After: " . ($newValue ? '<fg=green>active</>' : '<fg=red>inactive</>'));
+        $this->components->info("Feature '{$feature}' {$action}{$scopePart}.");
+
+        $beforeStatus = $isCurrentlyActive ? 'active' : 'inactive';
+        $afterStatus  = $newValue ? 'active' : 'inactive';
+
+        $this->line("  Before: {$beforeStatus}");
+        $this->line("   After: {$afterStatus}");
 
         return self::SUCCESS;
     }

--- a/src/PennantServiceProvider.php
+++ b/src/PennantServiceProvider.php
@@ -32,6 +32,7 @@ class PennantServiceProvider extends ServiceProvider
             $this->commands([
                 \Laravel\Pennant\Commands\FeatureMakeCommand::class,
                 \Laravel\Pennant\Commands\PurgeCommand::class,
+                \Laravel\Pennant\Commands\ToggleCommand::class,
             ]);
         }
 

--- a/tests/Feature/ToggleCommandTest.php
+++ b/tests/Feature/ToggleCommandTest.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
+use Laravel\Pennant\Feature;
+use Tests\TestCase;
+
+class ToggleCommandTest extends TestCase
+{
+    use LazilyRefreshDatabase;
+
+    public function test_it_can_toggle_a_feature_globally()
+    {
+        Feature::define('foo', true);
+
+        $this->assertTrue(Feature::active('foo'));
+
+        $this->artisan('pennant:toggle foo')
+            ->expectsOutputToContain("Feature 'foo' deactivated globally.")
+            ->expectsOutputToContain('Before: active')
+            ->expectsOutputToContain('After: inactive');
+
+        $this->assertFalse(Feature::active('foo'));
+
+        $this->artisan('pennant:toggle foo')
+            ->expectsOutputToContain("Feature 'foo' activated globally.")
+            ->expectsOutputToContain('Before: inactive')
+            ->expectsOutputToContain('After: active');
+
+        $this->assertTrue(Feature::active('foo'));
+    }
+
+    public function test_it_can_force_activate_a_feature()
+    {
+        Feature::define('bar', false);
+
+        $this->assertFalse(Feature::active('bar'));
+
+        $this->artisan('pennant:toggle bar --on')
+            ->expectsOutputToContain("Feature 'bar' activated globally.")
+            ->expectsOutputToContain('Before: inactive')
+            ->expectsOutputToContain('After: active');
+
+        $this->assertTrue(Feature::active('bar'));
+
+        $this->artisan(command: 'pennant:toggle bar --on')
+            ->expectsOutputToContain('After: active');
+
+        $this->assertTrue(Feature::active('bar'));
+    }
+
+    public function test_it_can_force_deactivate_a_feature()
+    {
+        Feature::define('foo', true);
+
+        $this->assertTrue(Feature::active('foo'));
+
+        $this->artisan('pennant:toggle foo --off')
+            ->expectsOutputToContain("Feature 'foo' deactivated globally.")
+            ->expectsOutputToContain('Before: active')
+            ->expectsOutputToContain('After: inactive');
+
+        $this->assertFalse(Feature::active('foo'));
+
+        $this->artisan('pennant:toggle foo --off')
+            ->expectsOutputToContain('After: inactive');
+
+        $this->assertFalse(Feature::active('foo'));
+    }
+
+    public function test_it_can_toggle_a_scoped_feature()
+    {
+        Feature::define('bar', false);
+
+        $this->assertFalse(Feature::for('user:tim')->active('bar'));
+
+        $this->artisan('pennant:toggle bar --scope=user:tim')
+            ->expectsOutputToContain("Feature 'bar' activated for scope 'user:tim'.")
+            ->expectsOutputToContain('Before: inactive')
+            ->expectsOutputToContain('After: active');
+
+        $this->assertTrue(Feature::for('user:tim')->active('bar'));
+        $this->assertFalse(Feature::active('bar')); // global unchanged
+
+        $this->artisan('pennant:toggle bar --scope=user:tim')
+            ->expectsOutputToContain("Feature 'bar' deactivated for scope 'user:tim'.")
+            ->expectsOutputToContain('Before: active')
+            ->expectsOutputToContain('After: inactive');
+
+        $this->assertFalse(Feature::for('user:tim')->active('bar'));
+    }
+
+    public function test_it_can_force_activate_for_scope()
+    {
+        Feature::define('foo', false);
+
+        $this->artisan('pennant:toggle foo --scope=team:dev --on')
+            ->expectsOutputToContain("Feature 'foo' activated for scope 'team:dev'.")
+            ->expectsOutputToContain('Before: inactive')
+            ->expectsOutputToContain('After: active');
+
+        $this->assertTrue(Feature::for('team:dev')->active('foo'));
+    }
+
+    public function test_it_handles_non_boolean_values()
+    {
+        Feature::define('bar', 'control');
+
+        $this->artisan('pennant:toggle bar')
+            ->expectsOutputToContain("Feature 'bar' deactivated globally.");
+
+        $this->assertFalse(Feature::value('bar'));
+
+        $this->artisan('pennant:toggle bar --on')
+            ->expectsOutputToContain("Feature 'bar' activated globally.");
+
+        $this->assertTrue(Feature::value('bar'));
+    }
+
+    public function test_it_activates_unknown_features()
+    {
+        $this->artisan('pennant:toggle unknown')
+            ->expectsOutputToContain("Feature 'unknown' activated globally.")
+            ->expectsOutputToContain('After: active');
+
+        $this->assertTrue(Feature::active('unknown'));
+    }
+}

--- a/tests/Feature/ToggleCommandTest.php
+++ b/tests/Feature/ToggleCommandTest.php
@@ -44,7 +44,7 @@ class ToggleCommandTest extends TestCase
 
         $this->assertTrue(Feature::active('bar'));
 
-        $this->artisan(command: 'pennant:toggle bar --on')
+        $this->artisan('pennant:toggle bar --on')
             ->expectsOutputToContain('After: active');
 
         $this->assertTrue(Feature::active('bar'));
@@ -81,7 +81,7 @@ class ToggleCommandTest extends TestCase
             ->expectsOutputToContain('After: active');
 
         $this->assertTrue(Feature::for('user:tim')->active('bar'));
-        $this->assertFalse(Feature::active('bar')); // global unchanged
+        $this->assertFalse(Feature::active('bar'));
 
         $this->artisan('pennant:toggle bar --scope=user:tim')
             ->expectsOutputToContain("Feature 'bar' deactivated for scope 'user:tim'.")
@@ -116,6 +116,24 @@ class ToggleCommandTest extends TestCase
             ->expectsOutputToContain("Feature 'bar' activated globally.");
 
         $this->assertTrue(Feature::value('bar'));
+    }
+
+    public function test_it_can_use_custom_store()
+    {
+        config(['pennant.stores.custom' => ['driver' => 'array']]);
+
+        Feature::define('foo', true);
+
+        Feature::store('custom')->for('test')->activate('foo');
+
+        $this->assertTrue(Feature::store('custom')->for('test')->active('foo'));
+
+        $this->artisan('pennant:toggle foo --store=custom --scope=test')
+            ->expectsOutputToContain("Feature 'foo' deactivated for scope 'test'.");
+
+        $this->assertFalse(Feature::store('custom')->for('test')->active('foo'));
+
+        $this->assertTrue(Feature::active('foo'));
     }
 
     public function test_it_activates_unknown_features()


### PR DESCRIPTION
**Description**

This PR adds a new Artisan command `pennant:toggle` that allows developers to quickly toggle feature flags on/off from the terminal — globally or for a specific scope.

Features:
- Normal toggle (flips current state)
- Force activation with `--on`
- Force deactivation with `--off`
- Scoped toggling with `--scope=`
- Optional `--store=` support

**Why?**

Feature flags are often toggled during development, debugging, staging → production transitions, or emergency rollbacks. Having a built-in Artisan command reduces friction compared to writing temporary code in routes or service providers.

**Tests added**  
- Full PHPUnit coverage in `tests/Feature/ToggleCommandTest.php`
- Covers global toggle, forced states, scoped behavior, non-boolean values, unknown features


```bash
php artisan pennant:toggle new-dashboard
# Feature 'new-dashboard' deactivated globally.
#   Before: active
#    After: inactive

php artisan pennant:toggle beta-access --on --scope=user:123
# Feature 'beta-access' activated for scope 'user:123'.
#   Before: inactive
#    After: active