### PR TITLE
fix: correct PHPDoc type for $aliases in PurgeCommand

### DIFF
--- a/src/Commands/PurgeCommand.php
+++ b/src/Commands/PurgeCommand.php
@@ -30,7 +30,7 @@ class PurgeCommand extends Command
     /**
      * The console command name aliases.
      *
-     * @var array
+     * @var string[]
      */
     protected $aliases = ['pennant:clear'];
 


### PR DESCRIPTION
**Description**

This PR fixes a PHPStan error that appears in CI workflows:

**Cause**  
The `$aliases` property in `PurgeCommand` used plain `@var array`, while the parent `Illuminate\Console\Command` uses `@var array<string>`.

**Fix**  
Changed PHPDoc to `@var array<string>` (covariant with parent).

**Impact**  
No runtime change — purely improves static analysis / type safety.

**Tests**  
No new tests needed (existing command tests cover behavior).

**Checklist**
- [x] Fixed reported PHPStan error
- [x] No breaking changes

Thanks for reviewing!