### PR TITLE
Remove redundant Pennant guidelines

### DIFF
--- a/resources/boost/guidelines/core.blade.php
+++ b/resources/boost/guidelines/core.blade.php
@@ -1,5 +1,0 @@
-# Laravel Pennant
-
-- This application uses Laravel Pennant for feature flag management, providing a flexible system for controlling feature availability across different organizations and user types.
-- IMPORTANT: Always use `search-docs` tool for version-specific Pennant documentation and updated code examples.
-- IMPORTANT: Activate `pennant-development` every time you're working with a Pennant or feature-flag-related task.

--- a/resources/boost/skills/pennant-development/SKILL.md
+++ b/resources/boost/skills/pennant-development/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pennant-development
-description: "Manages feature flags with Laravel Pennant. Activates when creating, checking, or toggling feature flags; showing or hiding features conditionally; implementing A/B testing; working with @feature directive; or when the user mentions feature flags, feature toggles, Pennant, conditional features, rollouts, or gradually enabling features."
+description: "Use when working with Laravel Pennant the official Laravel feature flag package. Trigger whenever the query mentions Pennant by name or involves feature flags or feature toggles in a Laravel project. Tasks include defining feature flags checking whether features are active creating class based features in `app/Features` using Blade `@feature` directives scoping flags to users or teams building custom Pennant storage drivers protecting routes with feature flags testing feature flags with Pest or PHPUnit and implementing A B testing or gradual rollouts with feature flags. Do not trigger for generic Laravel configuration authorization policies authentication or non Pennant feature management systems."
 license: MIT
 metadata:
   author: laravel


### PR DESCRIPTION
When we first added skill support, skill triggering wasn't reliable enough, so we added a `core.blade.php` guideline that duplicated instructions already in the Pennant skill — things like "always use `search-docs`" and "activate `pennant-development`" for Pennant tasks. This burned extra context tokens on every request.

We now have an eval system for testing and improving skill descriptions, so they trigger reliably. This means the redundant guideline file is no longer needed.

### Approach

- Remove the redundant `core.blade.php` guideline that duplicated the Pennant skill's own instructions
- Refine the skill description to be more specific about Laravel Pennant scoping, validated through trigger evals

Related to laravel/boost#645