### PR TITLE
Remove redundant "When to Apply" section from skill body

### DIFF
--- a/resources/boost/skills/pennant-development/SKILL.md
+++ b/resources/boost/skills/pennant-development/SKILL.md
@@ -7,14 +7,6 @@ metadata:
 ---
 # Pennant Features
 
-## When to Apply
-
-Activate this skill when:
-
-- Creating or checking feature flags
-- Managing feature rollouts
-- Implementing A/B testing
-
 ## Documentation
 
 Use `search-docs` for detailed Pennant patterns and documentation.


### PR DESCRIPTION
## Summary

- Removes the `## When to Apply` section from the Pennant skill file
- This section was already fully covered by the skill's `description` frontmatter — removing it doesn't affect skill triggering behavior

See laravel/boost#669 for the corresponding change in the Boost monorepo.