### PR TITLE
Only run facade documenter on merge of pull requests

### DIFF
--- a/.github/workflows/facade.yml
+++ b/.github/workflows/facade.yml
@@ -1,15 +1,16 @@
 name: facades
 
 on:
-  push:
-    branches:
-      - '*.x'
+  pull_request:
+      types:
+        - closed
 
 permissions:
   contents: write
 
 jobs:
   update:
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-22.04
 
     strategy:

--- a/src/Feature.php
+++ b/src/Feature.php
@@ -55,7 +55,7 @@ use Illuminate\Support\Facades\Facade;
  * @method static void deactivate(string|array $feature)
  * @method static void forget(string|array $features)
  *
- * @see \Laravel\Pennant\FeatureManager
+ * @see FeatureManager
  */
 class Feature extends Facade
 {


### PR DESCRIPTION
The facade documenter may start to compete with Pint, as it always resolves FQCN, where as Pint now imports classes to use short classes where possible.

To ensure we don't get into infinite loops, this PR ensures we only run the facade documenter on the pull request merged event, not on any arbitrary push.

This should stop the tool fighting each other and allow them live harmoniously 🧘 