### PR TITLE
[1.x] add defineMany method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /composer.lock
 /phpunit.xml
 /.phpunit.cache
+/.idea

--- a/src/Drivers/Decorator.php
+++ b/src/Drivers/Decorator.php
@@ -127,19 +127,11 @@ class Decorator implements CanListStoredFeatures, CanSetManyFeaturesForScopes, D
     /**
      * Define an initial feature flag state resolver.
      *
-     * @param  string|class-string|array<string, mixed>  $feature
+     * @param  string|class-string  $feature
      * @param  mixed  $resolver
      */
     public function define($feature, $resolver = null): void
     {
-        if (is_array($feature)) {
-            foreach ($feature as $name => $featureResolver) {
-                $this->define($name, $featureResolver);
-            }
-
-            return;
-        }
-
         if (func_num_args() === 1) {
             [$feature, $resolver] = [
                 $this->resolveFeatureName($feature, $this->container->make($feature)),
@@ -174,6 +166,18 @@ class Decorator implements CanListStoredFeatures, CanSetManyFeaturesForScopes, D
 
             return $this->resolve($feature, fn () => false, $scope);
         });
+    }
+
+    /**
+     * Define the initial feature flag state resolvers.
+     *
+     * @param  array<string|class-string, mixed>  $features
+     */
+    public function defineMany(array $features): void
+    {
+        foreach ($features as $feature => $resolver) {
+            $this->define($feature, $resolver);
+        }
     }
 
     /**

--- a/src/Drivers/Decorator.php
+++ b/src/Drivers/Decorator.php
@@ -127,11 +127,19 @@ class Decorator implements CanListStoredFeatures, CanSetManyFeaturesForScopes, D
     /**
      * Define an initial feature flag state resolver.
      *
-     * @param  string|class-string  $feature
+     * @param  string|class-string|array<string, mixed>  $feature
      * @param  mixed  $resolver
      */
     public function define($feature, $resolver = null): void
     {
+        if (is_array($feature)) {
+            foreach ($feature as $name => $featureResolver) {
+                $this->define($name, $featureResolver);
+            }
+
+            return;
+        }
+
         if (func_num_args() === 1) {
             [$feature, $resolver] = [
                 $this->resolveFeatureName($feature, $this->container->make($feature)),

--- a/tests/Feature/ArrayDriverTest.php
+++ b/tests/Feature/ArrayDriverTest.php
@@ -68,9 +68,9 @@ class ArrayDriverTest extends TestCase
         $this->assertFalse($false);
     }
 
-    public function test_it_can_register_features_via_array()
+    public function test_it_can_register_features_via_define_many()
     {
-        Feature::define([
+        Feature::defineMany([
             'foo' => fn () => true,
             'bar' => fn () => false,
             'baz' => 'value',

--- a/tests/Feature/ArrayDriverTest.php
+++ b/tests/Feature/ArrayDriverTest.php
@@ -68,6 +68,19 @@ class ArrayDriverTest extends TestCase
         $this->assertFalse($false);
     }
 
+    public function test_it_can_register_features_via_array()
+    {
+        Feature::define([
+            'foo' => fn () => true,
+            'bar' => fn () => false,
+            'baz' => 'value',
+        ]);
+
+        $this->assertTrue(Feature::active('foo'));
+        $this->assertFalse(Feature::active('bar'));
+        $this->assertSame('value', Feature::value('baz'));
+    }
+
     public function test_it_can_register_complex_values()
     {
         Feature::define('config', fn () => [

--- a/tests/Feature/DatabaseDriverTest.php
+++ b/tests/Feature/DatabaseDriverTest.php
@@ -88,9 +88,9 @@ class DatabaseDriverTest extends TestCase
         $this->assertCount(4, DB::getQueryLog());
     }
 
-    public function test_it_can_register_multiple_features_via_array()
+    public function test_it_can_register_multiple_features_via_define_many()
     {
-        Feature::define([
+        Feature::defineMany([
             'foo' => fn () => true,
             'bar' => fn () => false,
             'baz' => 'value',

--- a/tests/Feature/DatabaseDriverTest.php
+++ b/tests/Feature/DatabaseDriverTest.php
@@ -88,6 +88,19 @@ class DatabaseDriverTest extends TestCase
         $this->assertCount(4, DB::getQueryLog());
     }
 
+    public function test_it_can_register_multiple_features_via_array()
+    {
+        Feature::define([
+            'foo' => fn () => true,
+            'bar' => fn () => false,
+            'baz' => 'value',
+        ]);
+
+        $this->assertTrue(Feature::active('foo'));
+        $this->assertFalse(Feature::active('bar'));
+        $this->assertSame('value', Feature::value('baz'));
+    }
+
     public function test_it_can_register_complex_values()
     {
         Feature::define('config', fn () => [


### PR DESCRIPTION
 This PR adds a defineMany method, which means you can pass an array:

IE trying to accomplish the below at a bigger scale

```php
Feature::defineMany([
    'new-api' => app()->environment('production'),
    'custom-login' => app()->environment('legolas'),
    'redis-queue' => app()->environment('gimli'),
    // more....
]);
```

I guess I could just foreach and Feature::define(), inside, but thought I'd try this for the DX 

I've also added .idea to the gitignore cause phpstorm 🌚 