### PR TITLE
Add Feature::globally() helper for the global scope

### DIFF
--- a/src/Drivers/Decorator.php
+++ b/src/Drivers/Decorator.php
@@ -918,7 +918,7 @@ class Decorator implements CanListStoredFeatures, CanSetManyFeaturesForScopes, D
      */
     public function globally()
     {
-        return $this->for(null);
+        return $this->for('__laravel_global');
     }
 
     /**

--- a/src/Drivers/Decorator.php
+++ b/src/Drivers/Decorator.php
@@ -911,6 +911,17 @@ class Decorator implements CanListStoredFeatures, CanSetManyFeaturesForScopes, D
     }
 
     /**
+     * Create a pending feature interaction for the global (null) scope,
+     * ignoring the default scope resolver.
+     *
+     * @return \Laravel\Pennant\PendingScopedFeatureInteraction
+     */
+    public function globally()
+    {
+        return $this->for(null);
+    }
+
+    /**
      * Dynamically create a pending feature interaction.
      *
      * @param  string  $name

--- a/src/Drivers/Decorator.php
+++ b/src/Drivers/Decorator.php
@@ -536,6 +536,16 @@ class Decorator implements CanListStoredFeatures, CanSetManyFeaturesForScopes, D
     }
 
     /**
+     * Create a pending feature interaction for the global scope, ignoring the default scope resolver.
+     *
+     * @return \Laravel\Pennant\PendingScopedFeatureInteraction
+     */
+    public function globally()
+    {
+        return $this->for('__laravel_global');
+    }
+
+    /**
      * Activate the feature for everyone.
      *
      * @param  \BackedEnum|\UnitEnum|string|array<\BackedEnum|\UnitEnum|string>  $feature
@@ -908,17 +918,6 @@ class Decorator implements CanListStoredFeatures, CanSetManyFeaturesForScopes, D
         $this->container = $container;
 
         return $this;
-    }
-
-    /**
-     * Create a pending feature interaction for the global scope,
-     * ignoring the default scope resolver.
-     *
-     * @return \Laravel\Pennant\PendingScopedFeatureInteraction
-     */
-    public function globally()
-    {
-        return $this->for('__laravel_global');
     }
 
     /**

--- a/src/Drivers/Decorator.php
+++ b/src/Drivers/Decorator.php
@@ -911,7 +911,7 @@ class Decorator implements CanListStoredFeatures, CanSetManyFeaturesForScopes, D
     }
 
     /**
-     * Create a pending feature interaction for the global (null) scope,
+     * Create a pending feature interaction for the global scope,
      * ignoring the default scope resolver.
      *
      * @return \Laravel\Pennant\PendingScopedFeatureInteraction

--- a/src/Feature.php
+++ b/src/Feature.php
@@ -37,6 +37,7 @@ use Illuminate\Support\Facades\Facade;
  * @method static void flushMacros()
  * @method static mixed macroCall(string $method, array $parameters)
  * @method static \Laravel\Pennant\PendingScopedFeatureInteraction for(mixed $scope)
+ * @method static \Laravel\Pennant\PendingScopedFeatureInteraction globally()
  * @method static array load(\BackedEnum|\UnitEnum|string|array $features)
  * @method static array loadMissing(\BackedEnum|\UnitEnum|string|array $features)
  * @method static array loadAll()

--- a/tests/Feature/ArrayDriverTest.php
+++ b/tests/Feature/ArrayDriverTest.php
@@ -722,7 +722,7 @@ class ArrayDriverTest extends TestCase
 
         $this->assertTrue(Feature::globally()->active('foo'));
 
-        $this->assertSame([null], $scopes);
+        $this->assertSame(['__laravel_global'], $scopes);
     }
 
     public function test_it_uses_default_scope_for_loading_with_string()

--- a/tests/Feature/ArrayDriverTest.php
+++ b/tests/Feature/ArrayDriverTest.php
@@ -710,6 +710,21 @@ class ArrayDriverTest extends TestCase
         ], $scopes);
     }
 
+    public function test_it_can_interact_globally_ignoring_the_default_scope()
+    {
+        $scopes = [];
+        Feature::define('foo', function ($scope) use (&$scopes) {
+            $scopes[] = $scope;
+
+            return true;
+        });
+        Feature::resolveScopeUsing(fn () => 'default-scope');
+
+        $this->assertTrue(Feature::globally()->active('foo'));
+
+        $this->assertSame([null], $scopes);
+    }
+
     public function test_it_uses_default_scope_for_loading_with_string()
     {
         Feature::define('feature', fn () => false);


### PR DESCRIPTION
I get asked all the time when I use `Feature::for(null)` when I want a global flag. This would be a good helper to have inside the library instead of making a macro for it or a helper in the user's code.

```php
Feature::globally()->active('flag');
Feature::globally()->activate('flag');
```

It's a thin wrapper over the existing `Feature::for(null)` global-scope path (ignores the default scope resolver), so every pending-interaction method keeps working. Added the facade `@method` docblock and a test covering it.