### PR TITLE
Use object to represent global scope

### DIFF
--- a/src/Drivers/Decorator.php
+++ b/src/Drivers/Decorator.php
@@ -26,6 +26,7 @@ use Laravel\Pennant\Events\FeatureUpdated;
 use Laravel\Pennant\Events\FeatureUpdatedForAllScopes;
 use Laravel\Pennant\Events\UnexpectedNullScopeEncountered;
 use Laravel\Pennant\Feature;
+use Laravel\Pennant\GlobalScope;
 use Laravel\Pennant\LazilyResolvedFeature;
 use Laravel\Pennant\PendingScopedFeatureInteraction;
 use ReflectionClass;
@@ -542,7 +543,7 @@ class Decorator implements CanListStoredFeatures, CanSetManyFeaturesForScopes, D
      */
     public function globally()
     {
-        return $this->for('__laravel_global');
+        return $this->for(new GlobalScope);
     }
 
     /**

--- a/src/GlobalScope.php
+++ b/src/GlobalScope.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Laravel\Pennant;
+
+use Laravel\Pennant\Contracts\FeatureScopeSerializeable;
+
+class GlobalScope implements FeatureScopeSerializeable
+{
+    /**
+     * Serialize the feature scope for storage.
+     */
+    public function featureScopeSerialize(): string
+    {
+        return '__laravel_global';
+    }
+}

--- a/tests/Feature/ArrayDriverTest.php
+++ b/tests/Feature/ArrayDriverTest.php
@@ -19,6 +19,7 @@ use Laravel\Pennant\Events\FeatureUpdatedForAllScopes;
 use Laravel\Pennant\Events\UnexpectedNullScopeEncountered;
 use Laravel\Pennant\Events\UnknownFeatureResolved;
 use Laravel\Pennant\Feature;
+use Laravel\Pennant\GlobalScope;
 use RuntimeException;
 use Tests\TestCase;
 use Workbench\App\Models\User;
@@ -278,7 +279,7 @@ class ArrayDriverTest extends TestCase
         $this->assertFalse(Feature::for([$first, $second, $third])->allAreActive(['foo', 'bar']));
     }
 
-    public function test_null_is_same_as_global()
+    public function test_null_is_same_as_no_scope()
     {
         Feature::activate('foo');
 
@@ -722,7 +723,8 @@ class ArrayDriverTest extends TestCase
 
         $this->assertTrue(Feature::globally()->active('foo'));
 
-        $this->assertSame(['__laravel_global'], $scopes);
+        $this->assertCount(1, $scopes);
+        $this->assertInstanceOf(GlobalScope::class, $scopes[0]);
     }
 
     public function test_it_uses_default_scope_for_loading_with_string()

--- a/tests/Feature/DatabaseDriverTest.php
+++ b/tests/Feature/DatabaseDriverTest.php
@@ -27,6 +27,7 @@ use Laravel\Pennant\Events\FeatureUpdatedForAllScopes;
 use Laravel\Pennant\Events\UnexpectedNullScopeEncountered;
 use Laravel\Pennant\Events\UnknownFeatureResolved;
 use Laravel\Pennant\Feature;
+use Laravel\Pennant\GlobalScope;
 use RuntimeException;
 use Tests\TestCase;
 use Workbench\App\Models\Team;
@@ -322,7 +323,7 @@ class DatabaseDriverTest extends TestCase
         $this->assertCount(3, DB::getQueryLog());
     }
 
-    public function test_null_is_same_as_global()
+    public function test_null_is_same_as_no_scope()
     {
         Feature::activate('foo');
 
@@ -848,6 +849,23 @@ class DatabaseDriverTest extends TestCase
         $this->assertSame([
             null,
         ], $scopes);
+    }
+
+    public function test_it_can_interact_globally_ignoring_the_default_scope()
+    {
+        $scopes = [];
+        Feature::define('foo', function ($scope) use (&$scopes) {
+            $scopes[] = $scope;
+
+            return true;
+        });
+        Feature::resolveScopeUsing(fn () => 'default-scope');
+
+        $this->assertTrue(Feature::globally()->active('foo'));
+
+        $this->assertCount(1, $scopes);
+        $this->assertInstanceOf(GlobalScope::class, $scopes[0]);
+        $this->assertSame('__laravel_global', DB::table('features')->soleValue('scope'));
     }
 
     public function test_it_does_not_store_unknown_features()


### PR DESCRIPTION
Improves on https://github.com/laravel/pennant/pull/180 by adding a class to represent the global scope.

The stored string is still the same. This just ensures that developers don't have to deal with the stringy value and can instead use the object in the resolve function:


```php
use Laravel\Pennant\Facades\Feature;
use Laravel\Pennant\GlobalScope;

Feature::define('...', function (GlobalScope $scope) {
   // ...
});
```

It also allow developers to reference the global scope when checking or loading multiple values:

```php
use Laravel\Pennant\Facades\Feature;
use Laravel\Pennant\GlobalScope;

Feature::for([new GlobalScope, Auth::user()])->loadAll();
```

This is a small breaking change for anyone typing the resolve function, but I think it is worth it given we just released the feature and have not advertised it yet.